### PR TITLE
feat(backend): Phase 1 reorganization

### DIFF
--- a/backend/.env.example
+++ b/backend/.env.example
@@ -1,0 +1,9 @@
+# Port the API listens on. Defaults to 3000.
+PORT=3000
+
+# Allowed CORS origin for the Vite dev server. Override in production.
+FRONTEND_ORIGIN=http://localhost:5173
+
+# --- Phase 5 (planned, not yet read by the server) ----------------------
+# JWT_SECRET=replace-me-with-a-long-random-string
+# DATABASE_URL=postgres://user:pass@localhost:5432/equalview

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -1,0 +1,15 @@
+# Phase 1: bare Node container (no Puppeteer system deps yet — those
+# land in Phase 2 alongside the real scanner).
+FROM node:22-alpine
+
+WORKDIR /app
+
+COPY package*.json ./
+RUN npm install
+
+COPY . .
+
+ENV NODE_ENV=development
+EXPOSE 3000
+
+CMD ["npm", "run", "dev"]

--- a/backend/README.md
+++ b/backend/README.md
@@ -1,0 +1,69 @@
+# EqualView — Backend
+
+Express API that today serves the mock fixture from
+`backend/data/mockScanResults.js`. Phase 2 of the
+[project roadmap](../docs/plans/project-roadmap.md) replaces it with a
+real Puppeteer + axe-core scanner without changing the HTTP shape.
+
+## Layout
+
+```
+backend/
+├── index.js                    # Bootstrap: builds app, listens on $PORT
+├── app.js                      # Composition root (DI wiring)
+├── routes/
+│   ├── index.js                # Mount /api and /problems routers
+│   ├── scan.js                 # POST /api/scan, GET /api/scan-results
+│   └── problems.js             # GET /problems/:id
+├── controllers/
+│   └── scanController.js       # Request/response only — class with bound methods
+├── services/
+│   ├── axeTransformer.js       # Pure: axe results → API ScanResult shape
+│   └── ssrfGuard.js            # Pure: URL allow/deny rules
+├── data/
+│   └── mockScanResults.js      # Phase-1 fixture
+├── tests/                      # node:test + supertest
+│   ├── health.test.js
+│   ├── scan.test.js
+│   ├── ssrfGuard.test.js
+│   └── axeTransformer.test.js
+├── .env.example
+├── Dockerfile
+└── package.json
+```
+
+## Run
+
+```bash
+cd backend
+npm install
+npm run dev      # nodemon
+npm start        # plain node
+npm test         # node --test
+```
+
+API is on `http://localhost:3000` by default.
+
+## Environment
+
+| Var               | Default                  | Meaning                        |
+| ----------------- | ------------------------ | ------------------------------ |
+| `PORT`            | `3000`                   | Port the API listens on        |
+| `FRONTEND_ORIGIN` | `http://localhost:5173`  | CORS allow-origin for the SPA  |
+
+See [`.env.example`](.env.example) for the full list (Phase 5 adds
+`JWT_SECRET` and `DATABASE_URL`).
+
+## Endpoints
+
+| Method | Path                      | Notes                                      |
+| ------ | ------------------------- | ------------------------------------------ |
+| GET    | `/health`                 | liveness probe                             |
+| POST   | `/api/scan`               | run a scan (mock today; axe in Phase 2)    |
+| GET    | `/api/scan-results?url=`  | fetch scan results for a URL               |
+| GET    | `/problems/:id`           | look up a single problem                   |
+
+## See also
+
+- [`docs/plans/architecture-map.md`](../docs/plans/architecture-map.md) §6 — code architecture
+- [`docs/guides/axecore-integration.md`](../docs/guides/axecore-integration.md) — `this`-binding bug pattern

--- a/backend/app.js
+++ b/backend/app.js
@@ -1,0 +1,48 @@
+/**
+ * Composition root. The ONE place we instantiate concrete classes and
+ * wire them together. Everything else takes its dependencies via
+ * arguments — that's what makes the layers unit-testable without a DI
+ * framework. See docs/plans/architecture-map.md §6.5.
+ */
+const express = require('express');
+const cors = require('cors');
+
+const ScanController = require('./controllers/scanController');
+const mountRoutes = require('./routes');
+const ssrfGuard = require('./services/ssrfGuard');
+const mockScanResults = require('./data/mockScanResults');
+
+/**
+ * Build a fully-wired Express app. Exported separately from `index.js`
+ * so tests can `request(buildApp())` without binding a port.
+ *
+ * @param {object} [overrides]  optional dep overrides for testing
+ * @returns {import('express').Express}
+ */
+function buildApp(overrides = {}) {
+  const app = express();
+
+  const frontendOrigin =
+    process.env.FRONTEND_ORIGIN || 'http://localhost:5173';
+  app.use(cors({ origin: frontendOrigin }));
+  app.use(express.json());
+
+  app.get('/health', (_req, res) => {
+    res.status(200).json({ status: 'okay', message: 'Server is running!' });
+  });
+
+  // Today the controller still serves the mock fixture; in Phase 2 it
+  // will be constructed with a real ScanRunner instead.
+  const scanController =
+    overrides.scanController ||
+    new ScanController({
+      mockScanResults: overrides.mockScanResults || mockScanResults,
+      ssrfGuard: overrides.ssrfGuard || ssrfGuard,
+    });
+
+  mountRoutes(app, { scanController });
+
+  return app;
+}
+
+module.exports = buildApp;

--- a/backend/controllers/scanController.js
+++ b/backend/controllers/scanController.js
@@ -1,0 +1,79 @@
+/**
+ * ScanController — owns request/response for the scan endpoints.
+ *
+ * Today it delegates to the mock fixture; in Phase 2 the constructor
+ * will accept a `runner` (`ScanRunner`) and call `runner.run(url)`.
+ *
+ * Methods are bound in the constructor so they can be passed directly
+ * to `app.post('/api/scan', ctrl.postScan)` without losing `this`.
+ * See docs/guides/axecore-integration.md for the bug pattern this
+ * sidesteps.
+ */
+class ScanController {
+  /**
+   * @param {object} deps
+   * @param {object} deps.mockScanResults  Phase-1 fixture; replaced in Phase 2
+   * @param {{ validate: (s: string) => { ok: boolean, reason?: string } }} [deps.ssrfGuard]
+   */
+  constructor({ mockScanResults, ssrfGuard }) {
+    this.mockScanResults = mockScanResults;
+    this.ssrfGuard = ssrfGuard;
+
+    // Bind handlers once so router wiring stays clean.
+    this.postScan = this.postScan.bind(this);
+    this.getScanResults = this.getScanResults.bind(this);
+    this.getProblem = this.getProblem.bind(this);
+  }
+
+  /**
+   * POST /api/scan
+   * Body: { url: string }
+   */
+  postScan(req, res) {
+    const { url } = req.body || {};
+    if (this.ssrfGuard) {
+      const guard = this.ssrfGuard.validate(url);
+      if (!guard.ok) {
+        return res.status(400).json({ error: guard.reason });
+      }
+    }
+    console.log(`Received scan request for URL: ${url}`);
+    // TODO(Phase 2): call this.runner.run(url) and return the result.
+    return res.json(this.mockScanResults);
+  }
+
+  /**
+   * GET /api/scan-results?url=...
+   */
+  getScanResults(req, res) {
+    const { url } = req.query;
+    if (!url) {
+      return res.status(400).json({ error: 'Missing required ?url=' });
+    }
+    if (this.ssrfGuard) {
+      const guard = this.ssrfGuard.validate(url);
+      if (!guard.ok) {
+        return res.status(400).json({ error: guard.reason });
+      }
+    }
+    console.log(`Received request for scan results of URL: ${url}`);
+    return res.json(this.mockScanResults);
+  }
+
+  /**
+   * GET /problems/:id
+   * Look up a single problem inside the (mock) bucket structure.
+   */
+  getProblem(req, res) {
+    const { id } = req.params;
+    const allProblems = Object.values(this.mockScanResults.problems).flat();
+    const problem = allProblems.find((p) => p.id === id);
+    if (!problem) {
+      return res.status(404).json({ error: 'Problem not found' });
+    }
+    console.log(`Serving problem ${id}`);
+    return res.json(problem);
+  }
+}
+
+module.exports = ScanController;

--- a/backend/index.js
+++ b/backend/index.js
@@ -1,49 +1,14 @@
+/**
+ * Server entry point. Builds the app via the composition root and
+ * binds it to the configured port.
+ */
 require('dotenv').config();
-const express = require('express');
-const cors = require('cors');
 
-const mockScanResults = require('./data/mockScanResults');
-
-const app = express();
-
-app.use(cors({ origin: 'http://localhost:5173' })); // Allow frontend origin
-app.use(express.json());
+const buildApp = require('./app');
 
 const PORT = process.env.PORT || 3000;
 
-app.get('/health', (req, res) => {
-  try {
-    res.status(200).json({ status: 'okay', message: 'Server is running!' });
-  } catch (err) {
-    console.error(err);
-    res.status(500).json({ message: 'Internal Server Error' });
-  }
-});
-
-// TODO: replace mock results with a real Puppeteer + axe-core scan.
-// See docs/plans/axecore-integration-roadmap.md.
-app.post('/api/scan', (req, res) => {
-  const { url } = req.body;
-  console.log(`Received scan request for URL: ${url}`);
-  res.json(mockScanResults);
-});
-
-app.get('/api/scan-results', (req, res) => {
-  const { url } = req.query;
-  console.log(`Received request for scan results of URL: ${url}`);
-  res.json(mockScanResults);
-});
-
-app.get('/problems/:id', (req, res) => {
-  const { id } = req.params;
-  const allProblems = Object.values(mockScanResults.problems).flat();
-  const problem = allProblems.find((p) => p.id === id);
-  if (!problem) {
-    return res.status(404).json({ error: 'Problem not found' });
-  }
-  console.log(`Serving problem ${id}`);
-  res.json(problem);
-});
+const app = buildApp();
 
 app.listen(PORT, () => {
   console.log(`Server is running on port ${PORT}`);

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -1,20 +1,44 @@
 {
-  "name": "equalview",
+  "name": "equalview-backend",
   "version": "1.0.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "equalview",
+      "name": "equalview-backend",
       "version": "1.0.0",
-      "license": "ISC",
+      "license": "MPL-2.0",
       "dependencies": {
         "cors": "^2.8.6",
         "dotenv": "^17.3.1",
         "express": "^5.2.1"
       },
       "devDependencies": {
-        "nodemon": "^3.1.14"
+        "nodemon": "^3.1.14",
+        "supertest": "^7.2.2"
+      }
+    },
+    "node_modules/@noble/hashes": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/@noble/hashes/-/hashes-1.8.0.tgz",
+      "integrity": "sha512-jCs9ldd7NwzpgXDIf6P3+NrHh9/sD6CQdxHyjQI+h/6rDNo88ypBxxz45UDuZHz9r3tNz7N/VInSVoVdtXEI4A==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^14.21.3 || >=16"
+      },
+      "funding": {
+        "url": "https://paulmillr.com/funding/"
+      }
+    },
+    "node_modules/@paralleldrive/cuid2": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/@paralleldrive/cuid2/-/cuid2-2.3.1.tgz",
+      "integrity": "sha512-XO7cAxhnTZl0Yggq6jOgjiOHhbgcO4NqFqwSmQpjK3b6TEE6Uj/jfSk6wzYyemh3+I0sHirKSetjQwn5cZktFw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@noble/hashes": "^1.1.5"
       }
     },
     "node_modules/accepts": {
@@ -43,6 +67,20 @@
       "engines": {
         "node": ">= 8"
       }
+    },
+    "node_modules/asap": {
+      "version": "2.0.6",
+      "resolved": "https://registry.npmjs.org/asap/-/asap-2.0.6.tgz",
+      "integrity": "sha512-BSHWgDSAiKs50o2Re8ppvp3seVHXSRM44cdSsT9FfNEUUZLOGWVCsiWaRPWM1Znn+mqZ1OfVZ3z3DWEzSp7hRA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/asynckit": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/asynckit/-/asynckit-0.4.0.tgz",
+      "integrity": "sha512-Oei9OH4tRh0YqU3GxhX79dM/mwVgvbZJaSNaRk+bshkj0S5cfHcgYakreBjrHwatXKbz+IoIdYLxrKim2MjW0Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/balanced-match": {
       "version": "4.0.4",
@@ -180,6 +218,29 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/combined-stream": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/combined-stream/-/combined-stream-1.0.8.tgz",
+      "integrity": "sha512-FQN4MRfuJeHf7cBbBMJFXhKSDq+2kAArBlmRBvcvFE5BB1HZKXtSFASDhdlz9zOYwxh8lDdnvmMOe/+5cdoEdg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "delayed-stream": "~1.0.0"
+      },
+      "engines": {
+        "node": ">= 0.8"
+      }
+    },
+    "node_modules/component-emitter": {
+      "version": "1.3.1",
+      "resolved": "https://registry.npmjs.org/component-emitter/-/component-emitter-1.3.1.tgz",
+      "integrity": "sha512-T0+barUSQRTUQASh8bx02dl+DhF54GtIDY13Y3m9oWTklKbb3Wv974meRpeZ3lp1JpLVECWWNHC4vaG2XHXouQ==",
+      "dev": true,
+      "license": "MIT",
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/content-disposition": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/content-disposition/-/content-disposition-1.0.1.tgz",
@@ -220,6 +281,13 @@
         "node": ">=6.6.0"
       }
     },
+    "node_modules/cookiejar": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/cookiejar/-/cookiejar-2.1.4.tgz",
+      "integrity": "sha512-LDx6oHrK+PhzLKJU9j5S7/Y3jM/mUHvD/DeI1WQmJn652iPC5Y4TBzC9l+5OMOXlyTTA+SmVUPm0HQUwpD5Jqw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/cors": {
       "version": "2.8.6",
       "resolved": "https://registry.npmjs.org/cors/-/cors-2.8.6.tgz",
@@ -254,6 +322,16 @@
         }
       }
     },
+    "node_modules/delayed-stream": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/delayed-stream/-/delayed-stream-1.0.0.tgz",
+      "integrity": "sha512-ZySD7Nf91aLB0RxL4KGrKHBXl7Eds1DAmEdcoVawXnLD7SDhpNgtuII2aAkg7a7QS41jxPSZ17p4VdGnMHk3MQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=0.4.0"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -261,6 +339,17 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/dezalgo": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/dezalgo/-/dezalgo-1.0.4.tgz",
+      "integrity": "sha512-rXSP0bf+5n0Qonsb+SVVfNfIsimO4HEtmnIpPHY8Q1UCzKlQrDMfdobr8nJOOsRgWCyMRqeSBQzmWUMq7zvVig==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "asap": "^2.0.0",
+        "wrappy": "1"
       }
     },
     "node_modules/dotenv": {
@@ -334,6 +423,22 @@
         "node": ">= 0.4"
       }
     },
+    "node_modules/es-set-tostringtag": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/es-set-tostringtag/-/es-set-tostringtag-2.1.0.tgz",
+      "integrity": "sha512-j6vWzfrGVfyXxge+O0x5sh6cvxAog0a/4Rdd2K36zCMV5eJ+/+tOAngRO8cODMNWbVRdVlmGZQL2YS3yR8bIUA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "es-errors": "^1.3.0",
+        "get-intrinsic": "^1.2.6",
+        "has-tostringtag": "^1.0.2",
+        "hasown": "^2.0.2"
+      },
+      "engines": {
+        "node": ">= 0.4"
+      }
+    },
     "node_modules/escape-html": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/escape-html/-/escape-html-1.0.3.tgz",
@@ -392,6 +497,13 @@
         "url": "https://opencollective.com/express"
       }
     },
+    "node_modules/fast-safe-stringify": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/fast-safe-stringify/-/fast-safe-stringify-2.1.1.tgz",
+      "integrity": "sha512-W+KJc2dmILlPplD/H4K9l9LcAHAfPtP6BY84uVLXQ6Evcz9Lcg33Y2z1IVblT6xdY54PXYVHEv+0Wpq8Io6zkA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/fill-range": {
       "version": "7.1.1",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-7.1.1.tgz",
@@ -424,6 +536,64 @@
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/express"
+      }
+    },
+    "node_modules/form-data": {
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/form-data/-/form-data-4.0.5.tgz",
+      "integrity": "sha512-8RipRLol37bNs2bhoV67fiTEvdTrbMUYcFTiy3+wuuOnUog2QBHCZWXDRijWQfAkhBj2Uf5UnVaiWwA5vdd82w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "asynckit": "^0.4.0",
+        "combined-stream": "^1.0.8",
+        "es-set-tostringtag": "^2.1.0",
+        "hasown": "^2.0.2",
+        "mime-types": "^2.1.12"
+      },
+      "engines": {
+        "node": ">= 6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-db": {
+      "version": "1.52.0",
+      "resolved": "https://registry.npmjs.org/mime-db/-/mime-db-1.52.0.tgz",
+      "integrity": "sha512-sPU4uV7dYlvtWJxwwxHD0PuihVNiE7TyAbQ5SWxDCB9mUYvOgroQOwYQQOKPJ8CIbE+1ETVlOoK1UC2nU3gYvg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/form-data/node_modules/mime-types": {
+      "version": "2.1.35",
+      "resolved": "https://registry.npmjs.org/mime-types/-/mime-types-2.1.35.tgz",
+      "integrity": "sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "mime-db": "1.52.0"
+      },
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/formidable": {
+      "version": "3.5.4",
+      "resolved": "https://registry.npmjs.org/formidable/-/formidable-3.5.4.tgz",
+      "integrity": "sha512-YikH+7CUTOtP44ZTnUhR7Ic2UASBPOqmaRkRKxRbywPTe5VxF7RRCck4af9wutiZ/QKM5nME9Bie2fFaPz5Gug==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@paralleldrive/cuid2": "^2.2.2",
+        "dezalgo": "^1.0.4",
+        "once": "^1.4.0"
+      },
+      "engines": {
+        "node": ">=14.0.0"
+      },
+      "funding": {
+        "url": "https://ko-fi.com/tunnckoCore/commissions"
       }
     },
     "node_modules/forwarded": {
@@ -545,6 +715,22 @@
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.1.0.tgz",
       "integrity": "sha512-1cDNdwJ2Jaohmb3sg4OmKaMBwuC48sYni5HUw2DvsC8LjGTLK9h+eb1X6RyuOHe4hT0ULCW68iomhjUoKUqlPQ==",
       "license": "MIT",
+      "engines": {
+        "node": ">= 0.4"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/has-tostringtag": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/has-tostringtag/-/has-tostringtag-1.0.2.tgz",
+      "integrity": "sha512-NqADB8VjPFLM2V0VvHUewwwsw0ZWBaIdgo+ieHtK3hasLz4qeCRjYcqfB6AQrBggRKppKF8L52/VqdVsO47Dlw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "has-symbols": "^1.0.3"
+      },
       "engines": {
         "node": ">= 0.4"
       },
@@ -702,6 +888,29 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/methods": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/methods/-/methods-1.1.2.tgz",
+      "integrity": "sha512-iclAHeNqNm68zFtnZ0e+1L2yUIdvzNoauKU4WBA3VvH/vPFieF7qfRlwUZU+DA9P9bPXIS90ulxoUoCH23sV2w==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 0.6"
+      }
+    },
+    "node_modules/mime": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/mime/-/mime-2.6.0.tgz",
+      "integrity": "sha512-USPkMeET31rOMiarsBNIHZKLGgvKc/LrjofAnBlOttf5ajRvqiRA8QsenbcooctK6d6Ts6aqZXBA+XbkKthiQg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "mime": "cli.js"
+      },
+      "engines": {
+        "node": ">=4.0.0"
       }
     },
     "node_modules/mime-db": {
@@ -1123,6 +1332,42 @@
       "license": "MIT",
       "engines": {
         "node": ">= 0.8"
+      }
+    },
+    "node_modules/superagent": {
+      "version": "10.3.0",
+      "resolved": "https://registry.npmjs.org/superagent/-/superagent-10.3.0.tgz",
+      "integrity": "sha512-B+4Ik7ROgVKrQsXTV0Jwp2u+PXYLSlqtDAhYnkkD+zn3yg8s/zjA2MeGayPoY/KICrbitwneDHrjSotxKL+0XQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "component-emitter": "^1.3.1",
+        "cookiejar": "^2.1.4",
+        "debug": "^4.3.7",
+        "fast-safe-stringify": "^2.1.1",
+        "form-data": "^4.0.5",
+        "formidable": "^3.5.4",
+        "methods": "^1.1.2",
+        "mime": "2.6.0",
+        "qs": "^6.14.1"
+      },
+      "engines": {
+        "node": ">=14.18.0"
+      }
+    },
+    "node_modules/supertest": {
+      "version": "7.2.2",
+      "resolved": "https://registry.npmjs.org/supertest/-/supertest-7.2.2.tgz",
+      "integrity": "sha512-oK8WG9diS3DlhdUkcFn4tkNIiIbBx9lI2ClF8K+b2/m8Eyv47LSawxUzZQSNKUrVb2KsqeTDCcjAAVPYaSLVTA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cookie-signature": "^1.2.2",
+        "methods": "^1.1.2",
+        "superagent": "^10.3.0"
+      },
+      "engines": {
+        "node": ">=14.18.0"
       }
     },
     "node_modules/supports-color": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -1,14 +1,14 @@
 {
-  "name": "equalview",
+  "name": "equalview-backend",
   "version": "1.0.0",
-  "description": "An accessibility-focused web application that helps make the web more inclusive for everyone.",
+  "description": "EqualView API — Express backend that will host the axe-core scanner.",
   "main": "index.js",
   "scripts": {
     "start": "node index.js",
     "dev": "nodemon index.js",
-    "test": "echo \"No test runner wired up yet — see docs/plans/project-roadmap.md Phase 1\" && exit 0"
+    "test": "node --test tests/"
   },
-  "author": "",
+  "author": "Codr Labs",
   "license": "MPL-2.0",
   "type": "commonjs",
   "dependencies": {
@@ -17,6 +17,7 @@
     "express": "^5.2.1"
   },
   "devDependencies": {
-    "nodemon": "^3.1.14"
+    "nodemon": "^3.1.14",
+    "supertest": "^7.2.2"
   }
 }

--- a/backend/routes/index.js
+++ b/backend/routes/index.js
@@ -1,0 +1,17 @@
+/**
+ * Route mounting helper. Keeps `app.js` free of `/api/...` strings so
+ * each router owns its own URL prefix.
+ */
+const makeScanRouter = require('./scan');
+const makeProblemsRouter = require('./problems');
+
+/**
+ * @param {import('express').Express} app
+ * @param {{ scanController: import('../controllers/scanController') }} deps
+ */
+function mountRoutes(app, { scanController }) {
+  app.use('/api', makeScanRouter(scanController));
+  app.use('/problems', makeProblemsRouter(scanController));
+}
+
+module.exports = mountRoutes;

--- a/backend/routes/problems.js
+++ b/backend/routes/problems.js
@@ -1,0 +1,20 @@
+/**
+ * Problem-detail routes:
+ *   - GET /problems/:id
+ *
+ * In Phase 3 this will likely move under /api/problems/:id and gain
+ * a richer per-violation payload from axe-core.
+ */
+const { Router } = require('express');
+
+/**
+ * @param {import('../controllers/scanController')} controller
+ * @returns {import('express').Router}
+ */
+function makeProblemsRouter(controller) {
+  const router = Router();
+  router.get('/:id', controller.getProblem);
+  return router;
+}
+
+module.exports = makeProblemsRouter;

--- a/backend/routes/scan.js
+++ b/backend/routes/scan.js
@@ -1,0 +1,23 @@
+/**
+ * Scan-related routes:
+ *   - POST /api/scan
+ *   - GET  /api/scan-results
+ *
+ * Only knows about HTTP shape. All logic lives in ScanController.
+ *
+ * @typedef {import('../controllers/scanController')} ScanController
+ */
+const { Router } = require('express');
+
+/**
+ * @param {ScanController} controller
+ * @returns {import('express').Router}
+ */
+function makeScanRouter(controller) {
+  const router = Router();
+  router.post('/scan', controller.postScan);
+  router.get('/scan-results', controller.getScanResults);
+  return router;
+}
+
+module.exports = makeScanRouter;

--- a/backend/services/axeTransformer.js
+++ b/backend/services/axeTransformer.js
@@ -1,0 +1,116 @@
+/**
+ * axeTransformer — pure module that maps a raw axe-core results object
+ * into the API response shape the EqualView frontend consumes.
+ *
+ * This is currently a stub: until Phase 2 of the project roadmap wires
+ * Puppeteer + axe-core, the controller still serves the mock fixture
+ * verbatim. The transformer is here so:
+ *   1. The "right shape" is documented in code, not just in a markdown
+ *      doc, and
+ *   2. New code can be written against the interface today and have
+ *      a real implementation dropped in tomorrow.
+ *
+ * See:
+ *   - docs/plans/project-roadmap.md           (Phase 2)
+ *   - docs/plans/axecore-integration-roadmap.md
+ *   - docs/plans/architecture-map.md          §6.3
+ *
+ * Contract (when Phase 2 lands):
+ *   transform(axeResults) -> ScanResult
+ *
+ * @typedef {import('../../shared/types.js').ScanResult} ScanResult
+ */
+
+/**
+ * Map an axe `tags` array to one of EqualView's UI buckets.
+ * Pure helper — covered by unit tests in Phase 1.
+ *
+ * @param {string[]} tags
+ * @returns {'visualAccessibility' | 'structureAndSemantics' | 'multimedia'}
+ */
+function bucketFor(tags = []) {
+  const has = (t) => tags.includes(t);
+
+  // Multi-media: alt text, captions, transcripts, audio/video rules.
+  if (
+    has('cat.text-alternatives') ||
+    has('cat.media') ||
+    has('cat.time-and-media')
+  ) {
+    return 'multimedia';
+  }
+
+  // Structure & semantics: headings, landmarks, lists, tables, parsing.
+  if (
+    has('cat.structure') ||
+    has('cat.semantics') ||
+    has('cat.tables') ||
+    has('cat.parsing') ||
+    has('cat.aria') ||
+    has('cat.name-role-value')
+  ) {
+    return 'structureAndSemantics';
+  }
+
+  // Default to visual: contrast, color, sensory, focus.
+  return 'visualAccessibility';
+}
+
+/**
+ * Transform a raw axe-core run result into a ScanResult.
+ *
+ * NOTE: This is the *target* shape. Until the real scanner ships, the
+ * controller may bypass this transformer and return the mock fixture
+ * directly. Keep this function pure — no I/O, no globals.
+ *
+ * @param {object} axeResults  output of `axe.run(...)`
+ * @returns {ScanResult}
+ */
+function transform(axeResults) {
+  if (!axeResults || typeof axeResults !== 'object') {
+    return {
+      problems: {
+        visualAccessibility: [],
+        structureAndSemantics: [],
+        multimedia: [],
+      },
+      whatsGood: [],
+    };
+  }
+
+  const violations = Array.isArray(axeResults.violations)
+    ? axeResults.violations
+    : [];
+  const passes = Array.isArray(axeResults.passes) ? axeResults.passes : [];
+
+  /** @type {ScanResult['problems']} */
+  const problems = {
+    visualAccessibility: [],
+    structureAndSemantics: [],
+    multimedia: [],
+  };
+
+  for (const v of violations) {
+    const bucket = bucketFor(v.tags);
+    problems[bucket].push({
+      id: v.id,
+      name: v.help || v.description || v.id,
+      category: bucket,
+      rootCause: v.description || '',
+      codeSnippet: v.nodes?.[0]?.html || '',
+      solution: v.nodes?.[0]?.failureSummary
+        ? [v.nodes[0].failureSummary]
+        : [],
+      impact: v.impact || null,
+      helpUrl: v.helpUrl || null,
+      tags: v.tags || [],
+    });
+  }
+
+  return {
+    problems,
+    whatsGood: passes.map((p) => p.help || p.description || p.id),
+  };
+}
+
+module.exports = { transform, bucketFor };

--- a/backend/services/ssrfGuard.js
+++ b/backend/services/ssrfGuard.js
@@ -1,0 +1,84 @@
+/**
+ * ssrfGuard — validate that a user-supplied URL is safe to scan.
+ *
+ * Implements the SSRF policy from the project roadmap:
+ *   - require http(s) scheme
+ *   - reject `file:`, `data:`, `javascript:` etc.
+ *   - reject localhost / 127.0.0.0/8 / private IP ranges (RFC1918,
+ *     link-local, loopback, IPv6 ULA, etc.)
+ *
+ * See docs/plans/project-roadmap.md § "Open decisions — SSRF policy".
+ *
+ * Pure module — no I/O. Returns a typed result rather than throwing so
+ * callers can map a failure to a structured 4xx response.
+ *
+ * @typedef {{ ok: true, url: URL } | { ok: false, reason: string }} GuardResult
+ */
+
+const PRIVATE_IPV4_RANGES = [
+  /^10\./,
+  /^192\.168\./,
+  /^172\.(1[6-9]|2\d|3[0-1])\./,
+  /^127\./,
+  /^169\.254\./,
+  /^0\./,
+];
+
+const PRIVATE_HOSTS = new Set([
+  'localhost',
+  'localhost.localdomain',
+  'ip6-localhost',
+  'ip6-loopback',
+]);
+
+/**
+ * @param {string} hostname
+ * @returns {boolean}
+ */
+function isPrivateHost(hostname) {
+  const h = hostname.toLowerCase();
+  if (PRIVATE_HOSTS.has(h)) return true;
+
+  // IPv4 literal
+  if (/^\d{1,3}(\.\d{1,3}){3}$/.test(h)) {
+    return PRIVATE_IPV4_RANGES.some((rx) => rx.test(h));
+  }
+
+  // IPv6 loopback or unique-local
+  if (h === '::1' || h === '[::1]') return true;
+  if (/^\[?(fc|fd)/i.test(h)) return true;
+  if (/^\[?fe80/i.test(h)) return true;
+
+  return false;
+}
+
+/**
+ * Validate a URL against the SSRF policy.
+ *
+ * @param {string} input  raw URL string from the request
+ * @returns {GuardResult}
+ */
+function validate(input) {
+  if (typeof input !== 'string' || input.trim() === '') {
+    return { ok: false, reason: 'URL is required' };
+  }
+
+  let parsed;
+  try {
+    parsed = new URL(input);
+  } catch {
+    return { ok: false, reason: 'URL is not parseable' };
+  }
+
+  if (parsed.protocol !== 'http:' && parsed.protocol !== 'https:') {
+    return { ok: false, reason: `Unsupported protocol: ${parsed.protocol}` };
+  }
+
+  if (isPrivateHost(parsed.hostname)) {
+    return { ok: false, reason: 'Private/loopback hosts are not allowed' };
+  }
+
+  return { ok: true, url: parsed };
+}
+
+module.exports = { validate, isPrivateHost };

--- a/backend/tests/axeTransformer.test.js
+++ b/backend/tests/axeTransformer.test.js
@@ -1,0 +1,63 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { transform, bucketFor } = require('../services/axeTransformer');
+
+test('bucketFor maps multimedia tags', () => {
+  assert.equal(bucketFor(['cat.text-alternatives']), 'multimedia');
+  assert.equal(bucketFor(['cat.media']), 'multimedia');
+});
+
+test('bucketFor maps structure/semantics tags', () => {
+  assert.equal(bucketFor(['cat.structure']), 'structureAndSemantics');
+  assert.equal(bucketFor(['cat.aria']), 'structureAndSemantics');
+});
+
+test('bucketFor falls back to visualAccessibility', () => {
+  assert.equal(bucketFor([]), 'visualAccessibility');
+  assert.equal(bucketFor(['cat.color']), 'visualAccessibility');
+});
+
+test('transform handles empty / invalid input safely', () => {
+  const empty = transform(null);
+  assert.deepEqual(empty.problems.visualAccessibility, []);
+  assert.deepEqual(empty.whatsGood, []);
+});
+
+test('transform produces a ScanResult from a synthetic axe payload', () => {
+  const fixture = {
+    violations: [
+      {
+        id: 'color-contrast',
+        help: 'Elements must have sufficient color contrast',
+        description: 'Ensures the contrast between foreground and background colors meets WCAG AA',
+        helpUrl: 'https://dequeuniversity.com/rules/axe/4.7/color-contrast',
+        impact: 'serious',
+        tags: ['cat.color', 'wcag2aa'],
+        nodes: [
+          {
+            html: '<p style="color:#999">x</p>',
+            target: ['p'],
+            failureSummary: 'Fix any of the following: insufficient contrast',
+          },
+        ],
+      },
+      {
+        id: 'image-alt',
+        help: 'Images must have alternate text',
+        description: 'Ensures <img> elements have alternate text',
+        helpUrl: 'https://dequeuniversity.com/rules/axe/4.7/image-alt',
+        impact: 'critical',
+        tags: ['cat.text-alternatives', 'wcag2a'],
+        nodes: [{ html: '<img src="x">', target: ['img'], failureSummary: 'Add alt' }],
+      },
+    ],
+    passes: [{ id: 'document-title', help: 'Documents must have a title' }],
+  };
+
+  const out = transform(fixture);
+  assert.equal(out.problems.visualAccessibility.length, 1);
+  assert.equal(out.problems.multimedia.length, 1);
+  assert.equal(out.problems.visualAccessibility[0].impact, 'serious');
+  assert.equal(out.whatsGood[0], 'Documents must have a title');
+});

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -1,0 +1,19 @@
+/**
+ * Smoke test for the /health endpoint. Drives the composition root
+ * via supertest so we never bind a real port in tests.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const buildApp = require('../app');
+
+test('GET /health returns 200 with status payload', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/health');
+  assert.equal(res.status, 200);
+  assert.deepEqual(res.body, {
+    status: 'okay',
+    message: 'Server is running!',
+  });
+});

--- a/backend/tests/scan.test.js
+++ b/backend/tests/scan.test.js
@@ -1,0 +1,60 @@
+/**
+ * Supertests for the scan endpoints. They still hit the mock fixture
+ * (Phase 1) — when Phase 2 lands these become regression tests for the
+ * shape contract.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const request = require('supertest');
+
+const buildApp = require('../app');
+
+test('POST /api/scan returns the bucketed mock payload', async () => {
+  const app = buildApp();
+  const res = await request(app)
+    .post('/api/scan')
+    .send({ url: 'https://example.com' });
+  assert.equal(res.status, 200);
+  assert.ok(res.body.problems);
+  assert.ok(Array.isArray(res.body.problems.visualAccessibility));
+  assert.ok(Array.isArray(res.body.problems.structureAndSemantics));
+  assert.ok(Array.isArray(res.body.problems.multimedia));
+  assert.ok(Array.isArray(res.body.whatsGood));
+});
+
+test('POST /api/scan rejects a non-http URL', async () => {
+  const app = buildApp();
+  const res = await request(app)
+    .post('/api/scan')
+    .send({ url: 'file:///etc/passwd' });
+  assert.equal(res.status, 400);
+  assert.ok(res.body.error);
+});
+
+test('GET /api/scan-results requires ?url=', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/api/scan-results');
+  assert.equal(res.status, 400);
+});
+
+test('GET /api/scan-results returns the mock payload', async () => {
+  const app = buildApp();
+  const res = await request(app)
+    .get('/api/scan-results')
+    .query({ url: 'https://example.com' });
+  assert.equal(res.status, 200);
+  assert.ok(res.body.problems);
+});
+
+test('GET /problems/:id returns the matching problem', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/problems/contrast-1');
+  assert.equal(res.status, 200);
+  assert.equal(res.body.id, 'contrast-1');
+});
+
+test('GET /problems/:id returns 404 for an unknown id', async () => {
+  const app = buildApp();
+  const res = await request(app).get('/problems/does-not-exist');
+  assert.equal(res.status, 404);
+});

--- a/backend/tests/ssrfGuard.test.js
+++ b/backend/tests/ssrfGuard.test.js
@@ -1,0 +1,33 @@
+const test = require('node:test');
+const assert = require('node:assert/strict');
+
+const { validate } = require('../services/ssrfGuard');
+
+test('accepts a normal https URL', () => {
+  const r = validate('https://example.com');
+  assert.equal(r.ok, true);
+});
+
+test('rejects a missing url', () => {
+  assert.equal(validate('').ok, false);
+  assert.equal(validate(undefined).ok, false);
+});
+
+test('rejects unparseable strings', () => {
+  assert.equal(validate('not a url').ok, false);
+});
+
+test('rejects file:// and data: schemes', () => {
+  assert.equal(validate('file:///etc/passwd').ok, false);
+  assert.equal(validate('data:text/html,<h1>x</h1>').ok, false);
+  assert.equal(validate('javascript:alert(1)').ok, false);
+});
+
+test('rejects loopback and private hosts', () => {
+  assert.equal(validate('http://localhost').ok, false);
+  assert.equal(validate('http://127.0.0.1').ok, false);
+  assert.equal(validate('http://10.0.0.1').ok, false);
+  assert.equal(validate('http://192.168.1.1').ok, false);
+  assert.equal(validate('http://172.16.0.1').ok, false);
+  assert.equal(validate('http://169.254.169.254').ok, false);
+});

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,4 +1,20 @@
 services:
+  backend:
+    build:
+      context: ./backend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    volumes:
+      - ./backend:/app
+      - /app/node_modules
+    environment:
+      - NODE_ENV=development
+      - PORT=3000
+      - FRONTEND_ORIGIN=http://localhost:5173
+    stdin_open: true
+    tty: true
+
   frontend:
     build:
       context: ./frontend
@@ -12,13 +28,5 @@ services:
       - NODE_ENV=development
     stdin_open: true
     tty: true
-
-# Backend service will be added later
-# backend:
-#   build:
-#     context: ./backend
-#     dockerfile: Dockerfile
-#   ports:
-#     - "3000:3000"
-#   environment:
-#     - NODE_ENV=development
+    depends_on:
+      - backend

--- a/shared/types.js
+++ b/shared/types.js
@@ -1,0 +1,61 @@
+/**
+ * Shared JSDoc type definitions used by both the backend and the
+ * frontend. Keep this file dependency-free — nothing here may
+ * `require()` anything outside `shared/`.
+ *
+ * Backend usage (CommonJS):
+ *   /** @typedef {import('../shared/types.js').ScanResult} ScanResult *\/
+ *
+ * Frontend usage (ESM):
+ *   /** @typedef {import('../../shared/types.js').ScanResult} ScanResult *\/
+ */
+
+/**
+ * @typedef {'critical' | 'serious' | 'moderate' | 'minor' | null} Impact
+ */
+
+/**
+ * A single accessibility finding as the EqualView UI sees it.
+ *
+ * @typedef {object} Problem
+ * @property {string} id
+ * @property {string} name
+ * @property {string} category
+ * @property {string} rootCause
+ * @property {string} codeSnippet
+ * @property {string[]} solution
+ * @property {Impact} [impact]
+ * @property {string|null} [helpUrl]
+ * @property {string[]} [tags]
+ */
+
+/**
+ * Bucketed result returned by `GET /api/scan-results` and
+ * `POST /api/scan`.
+ *
+ * @typedef {object} ScanResult
+ * @property {{
+ *   visualAccessibility: Problem[],
+ *   structureAndSemantics: Problem[],
+ *   multimedia: Problem[]
+ * }} problems
+ * @property {string[]} whatsGood
+ */
+
+/**
+ * --- Phase 5 (planned) -------------------------------------------------
+ *
+ * @typedef {object} User
+ * @property {string} id
+ * @property {string} email
+ * @property {string} createdAt
+ *
+ * @typedef {object} StoredScan
+ * @property {string} id
+ * @property {string} userId
+ * @property {string} url
+ * @property {string} createdAt
+ * @property {ScanResult} results
+ */
+
+module.exports = {};


### PR DESCRIPTION
Split backend/index.js into a layered structure aligned with the Phase-1 deliverables in docs/plans/project-roadmap.md and the target architecture in docs/plans/architecture-map.md §6.

Layers:
- routes/{scan,problems,index}.js  - express routers, URLs only
- controllers/scanController.js    - class with bound handlers
- services/axeTransformer.js       - pure module, axe -> ScanResult
- services/ssrfGuard.js            - pure module, URL allow/deny
- app.js                           - composition root (DI)
- index.js                         - bootstrap (load .env, listen)

Operational:
- .env.example documenting PORT and FRONTEND_ORIGIN
- CORS now reads FRONTEND_ORIGIN (default http://localhost:5173)
- Dockerfile (node:22-alpine) + backend service in docker-compose
- backend/README.md with run/test/env tables

Tests (node:test + supertest):
- health, scan, ssrfGuard, axeTransformer (17 tests, all green)

Shared:
- shared/types.js JSDoc Problem / ScanResult / Impact, used by both backend and frontend via @typedef imports.