### PR TITLE
docs(plans): refresh post-reorg statuses, dedupe layout/migration con…

### DIFF
--- a/docs/README.md
+++ b/docs/README.md
@@ -35,8 +35,11 @@ leave it in place for history.
 - [`plans/axecore-integration-roadmap.md`](plans/axecore-integration-roadmap.md)
   — Replace mock scan data with a real axe-core scanner.
 - [`plans/codebase-reorganization.md`](plans/codebase-reorganization.md)
-  — Phase-1 + Phase-3 router reorg log; final repo layout and the
-  migration mapping from old → new file paths.
+  — Post-mortem of the Phase 1 + Phase 3 reorg (PRs #38–#40):
+  before/after tables and the rationale for each file move. The
+  current layout itself lives in the top-level
+  [`README.md`](../README.md); the architectural target lives in
+  [`plans/architecture-map.md`](plans/architecture-map.md) §6.
 
 ## Research
 

--- a/docs/plans/architecture-map.md
+++ b/docs/plans/architecture-map.md
@@ -399,7 +399,9 @@ backend does**.
 
 ### 2.1 Landing screen — `/`
 
-**File:** `frontend/src/landingPage.jsx`
+**File:** `frontend/src/pages/LandingPage.jsx`
+**Helpers:** `frontend/src/utils/urlValidator.js` (pure URL check),
+`frontend/src/lib/apiClient.js` (the only file that calls `fetch`).
 
 **Purpose.** Single entry point. Get a URL from the user and send them
 to a results page for it.
@@ -409,37 +411,41 @@ to a results page for it.
 - Single text input (`type="url"`, labeled for screen readers).
 - "Scan" button (disabled while empty or while a scan is in flight,
   `aria-busy` while scanning).
+- Inline `role="alert"` validation message (replaced the old
+  `window.alert`).
 - Hidden hint text exposed to screen readers.
 
 **What the user can do.**
 - Type a URL and press Enter or click Scan.
-- See a basic client-side URL validation error (`alert`, **planned**:
-  inline message instead).
+- See an inline client-side URL validation error.
 
 **What happens on submit (current).**
-1. `new URL(url)` validates the format client-side.
+1. `urlValidator.isValidUrl(url)` validates the format client-side.
 2. State flips to `scanning`; button shows "Redirecting…".
-3. After a 1.2 s `setTimeout`, `window.location.href` jumps to
-   `/scan-results?url=<encoded>`. The actual scan request is fired by
-   the next screen, not here.
+3. `useNavigate()` pushes `/scan-results?url=<encoded>` — no full page
+   reload. The actual scan request is fired by the next screen, not
+   here.
 
-**What happens on submit (target — Phase 2/3).**
+**What happens on submit (target — Phase 2).**
 1. Validate URL.
 2. `POST /api/scan { url }` to kick off the scan.
-3. On success, navigate via the router (decision pending) to
-   `/scan-results?url=...` carrying either the results or a job id.
-4. Show real loading/progress while the scan runs (kill the
-   `setTimeout`).
+3. On success, `useNavigate()` to `/scan-results?url=...` carrying
+   either the results or a job id.
+4. Show real loading/progress while the scan runs.
 
 **What the backend does today.** Nothing. The submit on this screen is
-purely a redirect.
+purely a client-side route change.
 
 ---
 
 ### 2.2 Scan results screen — `/scan-results?url=...`
 
-**File:** `frontend/src/ScanResults.jsx`
-**Sub-component:** `frontend/src/components/ProblemSolutionPage.jsx`
+**File:** `frontend/src/pages/ScanResultsPage.jsx`
+**Sub-components:** `frontend/src/components/ProblemCategoryBox.jsx`,
+`frontend/src/components/WhatsGood.jsx`,
+`frontend/src/components/ProblemSolutionPage.jsx`
+**Hook:** `frontend/src/hooks/useScan.js` (owns the
+`{ data, loading, error }` state machine)
 
 **Purpose.** Show what the scanner found for the URL in the query
 string, grouped so a non-technical user can understand it.
@@ -461,11 +467,13 @@ string, grouped so a non-technical user can understand it.
 - Click "← New Scan" → back to landing.
 
 **What happens on load (current).**
-1. `useEffect` reads `?url=` from the query string.
-2. If missing → error state ("No URL provided in query params").
-3. Otherwise: `GET /api/scan-results?url=<encoded>` → render the JSON.
+1. `useSearchParams()` reads `?url=` from the query string.
+2. `useScan(url)` validates it (missing → error state) and calls
+   `apiClient.getScanResults(url)`.
+3. The hook returns `{ data, loading, error }`; the page renders the
+   matching state.
 4. Backend ignores the URL today and returns the same mock object
-   regardless.
+   regardless (until Phase 2 lands the real scanner).
 
 **What happens on load (target — Phase 2).**
 1. Same kickoff, but the backend really runs Puppeteer + axe-core for
@@ -473,23 +481,30 @@ string, grouped so a non-technical user can understand it.
    - the bucketed shape (Option B), **or**
    - bucketed summary + `raw` axe arrays (Option C).
    Decision tracked in
-   [`project-roadmap.md`](project-roadmap.md#open-decisions-lock-in-before-they-block-a-phase).
+   [`project-roadmap.md`](project-roadmap.md#still-open).
 2. Render violations sorted by `impact`.
 3. Render an "incomplete" bucket if non-empty.
 
 **What the backend does.**
-- **Today:** `GET /api/scan-results?url=...` returns
-  `backend/data/mockScanResults.js` verbatim.
-- **Target:** route → controller → Puppeteer (`page.goto(url)`) →
-  inject axe-core → `axe.run()` → `axeTransformer` → JSON.
+- **Today:** `GET /api/scan-results?url=...` is served by
+  `routes/scan.js` → `ScanController.getScanResults` → returns
+  `backend/data/mockScanResults.js` verbatim. The SSRF guard rejects
+  bad URLs before the controller hits the fixture.
+- **Target:** same route/controller, but the controller delegates to
+  `ScanRunner` → Puppeteer (`page.goto(url)`) → inject axe-core →
+  `axe.run()` → `axeTransformer` → JSON.
 
 ---
 
-### 2.3 Problem detail "screen" — in-page view
+### 2.3 Problem detail screen — `/problems/:id`
 
-**File:** `frontend/src/components/ProblemSolutionPage.jsx`
-**Routing:** none yet — it's conditional rendering inside
-`ScanResults.jsx` based on `selectedProblem` state.
+**File (page):** `frontend/src/pages/ProblemPage.jsx`
+**Component (in-results inline detail):**
+`frontend/src/components/ProblemSolutionPage.jsx`
+**Hook:** `frontend/src/hooks/useProblem.js`
+**Routing:** real route (`/problems/:id`) shipped in PR #40, so the
+detail view is now refresh-safe and shareable. The in-page click on a
+results card still uses local state for the side-by-side view.
 
 **Purpose.** Show one problem in depth: what it is, why it matters,
 how to fix it, and where it appears on the page that was scanned.
@@ -632,14 +647,24 @@ contract that matters.
 ```
 frontend/src/
 ├── main.jsx                       # React bootstrap
-├── App.jsx                        # routing — pathname switch today,
-│                                  #   react-router [planned, Phase 3]
-├── landingPage.jsx                # Screen 2.1
-├── ScanResults.jsx                # Screen 2.2 (also hosts 2.3 today)
+├── App.jsx                        # BrowserRouter + Routes
+├── pages/
+│   ├── LandingPage.jsx            # Screen 2.1
+│   ├── ScanResultsPage.jsx        # Screen 2.2
+│   └── ProblemPage.jsx            # Screen 2.3 (route /problems/:id)
 ├── components/
-│   └── ProblemSolutionPage.jsx    # Screen 2.3
+│   ├── ProblemSolutionPage.jsx    # In-results inline detail
+│   ├── ProblemCategoryBox.jsx     # extracted from ScanResults
+│   └── WhatsGood.jsx              # extracted from ScanResults
+├── hooks/
+│   ├── useScan.js                 # { data, loading, error } for results
+│   └── useProblem.js              # single-problem fetch
+├── lib/
+│   └── apiClient.js               # the only file that imports `fetch`
+├── utils/
+│   └── urlValidator.js            # pure URL sanity check
 ├── data/
-│   └── mockScanResults.js         # offline fallback for tests / dev
+│   └── mockScanResults.js         # vitest-only fixture
 ├── styles/                        # plain CSS per screen
 └── __tests__/                     # Vitest + React Testing Library
 ```
@@ -662,21 +687,24 @@ frontend/src/
 
 ```
 backend/
-├── index.js                       # express app + middleware + listen
+├── index.js                       # bootstrap: load .env, listen
+├── app.js                         # composition root (DI wiring)
 ├── routes/
-│   ├── scan.js                    # /api/scan, /api/scan-results,
-│   │                              #   /problems/:id  [planned, Phase 1]
+│   ├── index.js                   # mounts /api and /problems
+│   ├── scan.js                    # /api/scan, /api/scan-results
+│   ├── problems.js                # /problems/:id
 │   ├── auth.js                    # /api/auth/*  [planned, Phase 5]
 │   └── scans.js                   # /api/scans/* (history)  [planned, Phase 5]
 ├── controllers/
-│   ├── scanController.js          # request/response + drives Puppeteer
-│   │                              #   [planned, Phase 1]
+│   ├── scanController.js          # request/response, bound handlers
 │   ├── authController.js          # signup/login/logout/me  [planned, Phase 5]
 │   └── scansController.js         # list / get / delete saved scans  [planned, Phase 5]
 ├── services/
-│   ├── axeTransformer.js          # axe → API shape, pure function,
-│   │                              #   easy to unit test  [planned, Phase 1]
-│   └── auth.js                    # password hashing, JWT sign/verify
+│   ├── axeTransformer.js          # axe → API shape, pure function;
+│   │                              #   stub today, body in Phase 2
+│   ├── ssrfGuard.js               # URL allow/deny, pure function
+│   ├── scanRunner.js              # Puppeteer driver  [planned, Phase 2]
+│   └── authService.js             # password hashing, JWT sign/verify
 │                                  #   [planned, Phase 5]
 ├── middleware/
 │   └── requireAuth.js             # gate protected routes  [planned, Phase 5]
@@ -687,13 +715,16 @@ backend/
 │       ├── usersRepo.js
 │       └── scansRepo.js
 ├── data/
-│   └── mockScanResults.js         # used as a fixture in tests
-├── tests/                         # supertest + chosen runner
-│                                  #   [planned, Phase 1 — runner
-│                                  #   decision still open]
-├── Dockerfile                     # [planned, Phase 1]
-└── .env.example                   # PORT, FRONTEND_ORIGIN, JWT_SECRET,
-                                   #   DATABASE_URL  [planned, Phase 1/5]
+│   └── mockScanResults.js         # Phase-1 fixture (also used in tests)
+├── tests/                         # node:test + supertest
+│   ├── health.test.js
+│   ├── scan.test.js
+│   ├── ssrfGuard.test.js
+│   └── axeTransformer.test.js
+├── Dockerfile                     # node:22-alpine
+├── README.md                      # run / test / env tables
+└── .env.example                   # PORT, FRONTEND_ORIGIN
+                                   #   (JWT_SECRET, DATABASE_URL: P5)
 ```
 
 **Layered responsibilities.**
@@ -720,7 +751,7 @@ For each screen, the request → response contract is:
 | Problem      | (in-payload) **or** `GET /problems/:id` | one problem object                         |
 
 The exact JSON shape depends on the open "Scan API shape" decision in
-[`project-roadmap.md`](project-roadmap.md#open-decisions-lock-in-before-they-block-a-phase).
+[`project-roadmap.md`](project-roadmap.md#still-open).
 Whichever option wins, the per-violation fields we surface to the UI
 are fixed by axe-core itself: `id`, `help`, `helpUrl`, `impact`,
 `tags`, and `nodes[].{html, target, failureSummary}`. Those are the
@@ -736,12 +767,15 @@ moves.
 
 | Symptom                                                    | Likely file                              |
 | ---------------------------------------------------------- | ---------------------------------------- |
-| Landing page: clicking Scan does nothing                   | `frontend/src/landingPage.jsx`           |
-| Results page stays on "Fetching scan results..."           | network tab → `/api/scan-results` → `backend/index.js` (today) / `routes/scan.js` (target) |
-| Results render but a problem card crashes on click         | `frontend/src/ScanResults.jsx` (`setSelectedProblem` wiring) + `components/ProblemSolutionPage.jsx` |
-| CORS error in browser console                              | `backend/index.js` `cors({ origin })` and `FRONTEND_ORIGIN` env |
-| "MODULE_NOT_FOUND: cors" on backend start                  | `backend/package.json` (dep must live there, not at repo root) |
-| Scan returns 500 on a real URL                             | `controllers/scanController.js` Puppeteer error handling [planned, Phase 4] |
+| Landing page: clicking Scan does nothing                   | `frontend/src/pages/LandingPage.jsx` (+ `utils/urlValidator.js`) |
+| Landing page: navigates but results page is blank/errors   | `frontend/src/hooks/useScan.js` + `lib/apiClient.js` |
+| Results page stays on "Fetching scan results..."           | network tab → `/api/scan-results` → `backend/routes/scan.js` → `controllers/scanController.js` |
+| Results render but a problem card crashes on click         | `frontend/src/pages/ScanResultsPage.jsx` (`setSelectedProblem`) + `components/ProblemSolutionPage.jsx` |
+| `/problems/:id` deep link 404s                             | `frontend/src/pages/ProblemPage.jsx` + `hooks/useProblem.js` (frontend) and `backend/routes/problems.js` (backend) |
+| URL form submission rejected with "ssrf"                   | `backend/services/ssrfGuard.js`          |
+| CORS error in browser console                              | `backend/app.js` (`cors({ origin: process.env.FRONTEND_ORIGIN })`) and `backend/.env.example` |
+| "MODULE_NOT_FOUND" on backend start                        | `backend/package.json` (dep must live there, not at repo root) |
+| Scan returns 500 on a real URL                             | `services/scanRunner.js` Puppeteer error handling [planned, Phase 2/4] |
 | Same mock returned for every URL                           | expected today — until Phase 2 lands     |
 
 ---
@@ -787,13 +821,13 @@ Define it **once**, in a shared file that both sides can `@import`
 from JSDoc. No runtime cost; full editor autocomplete; survives the
 move to TypeScript later if we want it.
 
-Suggested location: `shared/types.js` at the repo root (re-exported
-from `backend/types.js` and `frontend/src/types.js` as thin
-wrappers, since neither tool resolves outside its own folder by
-default).
+Location: `shared/types.js` at the repo root (shipped in PR #38).
+Backend and frontend reference the typedefs via relative
+`@typedef {import('../../shared/types.js').…}` JSDoc imports — no
+build step, no runtime cost.
 
 ```js
-// shared/types.js  [planned, P1]
+// shared/types.js — shipped in PR #38
 
 /**
  * @typedef {'minor'|'moderate'|'serious'|'critical'} Impact
@@ -847,7 +881,7 @@ default).
 
 The exact shape of `ScanResult` is locked by the open "Scan API
 shape" decision in
-[`project-roadmap.md`](project-roadmap.md#open-decisions-lock-in-before-they-block-a-phase).
+[`project-roadmap.md`](project-roadmap.md#still-open).
 Whatever wins, **per-violation fields are fixed by axe** (id, help,
 helpUrl, impact, tags, nodes).
 
@@ -1092,34 +1126,49 @@ classes and wires them together. Everywhere else takes its
 dependencies via constructor or function arguments. This is what
 makes the layers unit-testable without a DI framework.
 
-**Backend composition root (`backend/app.js` or `backend/index.js`):**
+**Backend composition root (`backend/app.js`).**
+
+The skeleton is shipped — today it wires the controller against the
+mock fixture; the Phase-2 lines below are pseudo-code:
 
 ```js
-// pseudo-code — [planned, P1/P2]
-const pool       = new BrowserPool({ maxConcurrency: 2 });
-const runner     = new ScanRunner({ pool, transform, validateUrl });
-const scanCtrl   = new ScanController({ runner });
-const authSvc    = new AuthService({ jwtSecret: env.JWT_SECRET });   // P5
-const usersRepo  = new UsersRepo(db);                                 // P5
-const scansRepo  = new ScansRepo(db);                                 // P5
-const authCtrl   = new AuthController({ authSvc, usersRepo });        // P5
-const requireAuth = makeRequireAuth(authSvc);                         // P5
+// shipped (PR #38)
+const scanController = new ScanController({ mockScanResults, ssrfGuard });
+mountRoutes(app, { scanController });
 
-app.use('/api/scan',  makeScanRouter(scanCtrl));
-app.use('/api/auth',  makeAuthRouter(authCtrl));                      // P5
-app.use('/api/scans', requireAuth, makeScansRouter(scanCtrl, scansRepo)); // P5
+// [planned, P2] — replace mockScanResults with a real runner
+const pool       = new BrowserPool({ maxConcurrency: 2 });
+const runner     = new ScanRunner({ pool, transform, validateUrl: ssrfGuard.validate });
+const scanCtrl   = new ScanController({ runner, ssrfGuard });
+
+// [planned, P5] — auth + history
+const authSvc    = new AuthService({ jwtSecret: env.JWT_SECRET });
+const usersRepo  = new UsersRepo(db);
+const scansRepo  = new ScansRepo(db);
+const authCtrl   = new AuthController({ authSvc, usersRepo });
+const requireAuth = makeRequireAuth(authSvc);
+
+app.use('/api/auth',  makeAuthRouter(authCtrl));
+app.use('/api/scans', requireAuth, makeScansRouter(scanCtrl, scansRepo));
 ```
 
-**Frontend composition root (`frontend/src/main.jsx`):**
+**Frontend composition root.**
+
+`frontend/src/main.jsx` mounts `<App/>`; `App.jsx` owns the
+`BrowserRouter` + `Routes` (PR #40). The `ApiClient` singleton is
+imported from `lib/apiClient.js` directly today — wrapping it in a
+context only becomes useful when auth state lands in P5:
 
 ```jsx
-// pseudo-code — [planned, P3/P5]
-const api = new ApiClient({ baseUrl: '/api' });
+// shipped (PR #40)
+ReactDOM.createRoot(document.getElementById('root')).render(<App />);
 
+// [planned, P5] — providers around the router for auth state
+const api = apiClient; // already a singleton
 ReactDOM.createRoot(document.getElementById('root')).render(
   <ApiProvider value={api}>
-    <AuthProvider api={api}>           {/* P5 */}
-      <RouterProvider router={router}/>
+    <AuthProvider api={api}>
+      <App />
     </AuthProvider>
   </ApiProvider>
 );
@@ -1140,23 +1189,33 @@ ReactDOM.createRoot(document.getElementById('root')).render(
 | `useScan`              | `ApiClient`                                  | render in a test wrapper with a stub api |
 | Page components        | hooks                                        | `vi.mock('../hooks/useScan', …)`         |
 
-### 6.6 Mapping back to today's repo
+### 6.6 Where today's repo sits on this map
 
-Today the backend has none of the above classes — it has one file
-(`backend/index.js`) with three inline route handlers reading a
-mock module. **That's fine.** The point of §6 is to make the
-direction-of-travel explicit so each new piece lands in the right
-slot:
+**What shipped in Phase 1 + 3 (PRs #38, #40).** The backend now has
+the layered structure described above: `routes/` → `controllers/` →
+`services/` (`axeTransformer` stub, `ssrfGuard`), with `app.js` as the
+composition root. The frontend uses `react-router-dom` v7, with
+`pages/` for screens, `hooks/` for state machines (`useScan`,
+`useProblem`), `lib/apiClient.js` as the only file that calls `fetch`,
+and `utils/urlValidator.js` for client-side URL checks. The
+`/problems/:id` route is real and refresh-safe. CORS reads
+`FRONTEND_ORIGIN` from `.env`, and tests run via `node:test` +
+`supertest` (backend, 17 / 17) and Vitest (frontend, 19 / 19).
 
-| Today                          | Goes to (phase)                                       |
-| ------------------------------ | ----------------------------------------------------- |
-| inline `app.post('/api/scan')` | `routes/scan.js` + `ScanController.postScan` (P1)     |
-| `mockScanResults` import       | replaced by `runner.run(url)` (P2); kept as a P1 test fixture |
-| `cors({ origin: 'http://...' })` | reads `FRONTEND_ORIGIN` env (P1)                    |
-| `fetch('/api/scan-results…')` in `ScanResults.jsx` | `useScan(url)` → `ApiClient.getScanResults(url)` (P3 refactor, optional earlier) |
-| `selectedProblem` in component state | `/problems/:id` route + `useProblem(id)` hook (P3) |
-| `window.location.href = …` in `landingPage.jsx` | `useNavigate()` + `apiClient.runScan(url)` (P2/P3) |
+For the full before/after detail and the migration mapping, see
+[`codebase-reorganization.md`](codebase-reorganization.md).
 
-Each row above is a small, mechanical refactor — not a rewrite.
-That's the test of whether the architecture in §6 is right: if
-adopting it requires throwing today's code away, it's wrong.
+**What still has to land before §6.3 / §6.4 are fully realized:**
+
+| Slot                                    | Phase | What's missing                                                  |
+| --------------------------------------- | ----- | --------------------------------------------------------------- |
+| `services/scanRunner.js` + `BrowserPool` | P2   | Real Puppeteer driver replacing the `mockScanResults` injection |
+| `services/axeTransformer.js` body       | P2    | Implement the chosen response shape (Option A/B/C)              |
+| Loading/error/empty UI on results page  | P3    | Drive from `useScan`'s `{ data, loading, error }` triple        |
+| Severity badges / WCAG filters / "Needs review" bucket | P3 | Need real axe data first                                |
+| `services/authService.js`, `db/`, repos | P5    | Auth + persistence; `LoginPage`, `MyScansPage`, `useAuth`       |
+| `ApiProvider` / `AuthProvider` context  | P5    | Wrap `<App/>` once auth state needs to live above the router    |
+
+Each row is a small, mechanical addition — not a rewrite. That's the
+test of whether the architecture in §6 is right: if landing it
+requires throwing today's code away, it's wrong.

--- a/docs/plans/axecore-integration-roadmap.md
+++ b/docs/plans/axecore-integration-roadmap.md
@@ -1,6 +1,7 @@
 # Axe-Core Integration Roadmap
 
-**Status:** Not started
+**Status:** Phase 1 scaffolding shipped (PR #38). Phase 2 (real
+Puppeteer + axe wiring) not started.
 **Owner:** Eli Iguer
 **Reference guide:** [`../guides/axecore-integration.md`](../guides/axecore-integration.md)
 
@@ -20,43 +21,44 @@ scanner, end-to-end, behind the existing API surface
 
 These are tracked as later phases below.
 
-## Constraints / decisions to lock in before coding
+## Constraints / decisions
 
-These are open questions called out during housekeeping. Resolve them in
-issues or a design comment before Phase 1.
+The full list of resolved + still-open decisions lives in the parent
+[`project-roadmap.md`](project-roadmap.md#decisions). Phase 2 is
+specifically blocked on the **scan response shape** and **sync vs
+async** decisions there. Routing, SSRF policy, and the backend test
+runner are resolved.
 
-- [ ] **Routing on the frontend**: keep the `window.location.pathname`
-      switch in `App.jsx`, or introduce `react-router` now? Real scans
-      will produce shareable URLs, which makes a router more attractive.
-- [ ] **Scan response shape**: keep the current
-      `{ problems: { visualAccessibility, structureAndSemantics, multimedia }, whatsGood }`
-      shape, or expose raw axe-core categories (violations, passes,
-      incomplete, inapplicable) and let the UI bucket them?
-- [ ] **Sync vs async API**: does `POST /api/scan` block until the scan
-      finishes (simpler), or return a job id that the client polls
-      (better UX for slow sites)? First iteration: sync, with a
-      generous timeout.
-- [ ] **URL allow/deny policy**: at minimum block private IP ranges and
-      `file://`/`data:` URLs to prevent SSRF.
+## File layout (current)
 
-## File layout (target)
-
-These paths are referenced by the integration guide and should be
-created during Phase 1:
+This is what's on disk after PR #38 — Phase 2 fills in the bodies, it
+doesn't add new top-level files apart from `services/scanRunner.js`:
 
 ```
 backend/
+├── index.js                    # bootstrap (load .env, listen)
+├── app.js                      # composition root (DI wiring)
 ├── controllers/
-│   └── scanController.js       # request handling + Puppeteer driver
+│   └── scanController.js       # request/response, bound handlers;
+│                               #   Phase 2 swaps mockScanResults for
+│                               #   a ScanRunner injection
 ├── services/
-│   └── axeTransformer.js       # axe-core results → frontend shape
+│   ├── axeTransformer.js       # stub today; Phase 2 fills the body
+│   ├── ssrfGuard.js            # blocks non-http(s), localhost, RFC1918
+│   └── scanRunner.js           # [planned, Phase 2] Puppeteer driver
 ├── routes/
-│   └── scan.js                 # express.Router for /api/scan*
+│   ├── index.js                # mounts /api and /problems
+│   ├── scan.js                 # POST /api/scan, GET /api/scan-results
+│   └── problems.js             # GET /problems/:id
 ├── data/
-│   └── mockScanResults.js      # kept as a fixture for tests
-├── tests/
-│   └── scan.test.js
+│   └── mockScanResults.js      # fixture; only consumer in Phase 2 is tests
+├── tests/                      # node:test + supertest
+│   ├── health.test.js
+│   ├── scan.test.js
+│   ├── ssrfGuard.test.js
+│   └── axeTransformer.test.js
 ├── Dockerfile
+├── README.md
 └── .env.example                # committed; .env stays gitignored
 ```
 
@@ -64,23 +66,34 @@ backend/
 
 ### Phase 1 — Wire up a real scanner (MVP)
 
+Scaffolding shipped in PR #38. The remaining unchecked items are the
+ones that actually swap the mock for real scans (Phase 2 in the parent
+project-roadmap):
+
 - [ ] Add `puppeteer` and `axe-core` to `backend/package.json`; pin
-      versions
-- [ ] Create `backend/controllers/scanController.js` with URL validation
-      and an SSRF guard (reject non-http(s), private IPs, localhost)
+      versions.
+- [x] Create `backend/controllers/scanController.js` with URL validation
+      and an SSRF guard (reject non-http(s), private IPs, localhost).
+      (URL validation lives in `services/ssrfGuard.js` and is wired
+      into the controller; PR #38.)
 - [ ] Create `backend/services/axeTransformer.js`; cover the mapping in
-      `backend/tests/`
-- [ ] Extract routes into `backend/routes/scan.js`; mount from
-      `index.js`
-- [ ] Add `backend/Dockerfile` (must include the system libs Puppeteer's
-      bundled Chromium needs)
-- [ ] Add `backend/.env.example` documenting `PORT`,
-      `FRONTEND_ORIGIN`, etc.
-- [ ] Update `docker-compose.yml` with the backend service
-- [ ] Frontend: keep using the existing endpoints; no shape change if
-      possible
+      `backend/tests/`. (Stub + contract + unit-test scaffold shipped;
+      body still to write.)
+- [x] Extract routes into `backend/routes/scan.js`; mount from
+      `index.js`. (Done via `routes/index.js` + `app.js` composition
+      root; PR #38.)
+- [x] Add `backend/Dockerfile` (must include the system libs Puppeteer's
+      bundled Chromium needs). (Minimal `node:22-alpine` Dockerfile
+      shipped in PR #38; Chromium system deps will be added when
+      Puppeteer actually lands.)
+- [x] Add `backend/.env.example` documenting `PORT`,
+      `FRONTEND_ORIGIN`, etc. (PR #38.)
+- [x] Update `docker-compose.yml` with the backend service. (PR #38.)
+- [x] Frontend: keep using the existing endpoints; no shape change if
+      possible. (Frontend now consumes them via `lib/apiClient.js` +
+      `useScan` / `useProblem` hooks, same shape; PR #40.)
 - [ ] Smoke-test against a known-bad page (e.g. a page with missing
-      alts and low contrast) and a known-clean page
+      alts and low contrast) and a known-clean page.
 
 **Done when:** `POST /api/scan { url }` returns real axe-core results
 in the existing shape, and `mockScanResults.js` is only referenced from
@@ -117,8 +130,13 @@ tests.
 
 - **Puppeteer in Docker**: Alpine images frequently miss Chromium
   dependencies. Either install them or use a Debian-based base image.
-- **CORS**: backend currently only allows `http://localhost:5173`. Any
-  deployment will need this to be config-driven via `FRONTEND_ORIGIN`.
+  The current `backend/Dockerfile` is `node:22-alpine` and works for
+  the mock — Phase 2 will need to revisit this when Chromium lands.
+- **CORS**: ~~backend currently only allows `http://localhost:5173`~~
+  Now config-driven via `FRONTEND_ORIGIN` in `backend/app.js` (PR #38),
+  defaulting to `http://localhost:5173`.
 - **`this` binding in controller**: the integration guide previously
   shipped a bug where `req.body` destructuring lost `this` on
-  `scanWebsite`; bind the route handler or use an arrow method.
+  `scanWebsite`. The shipped `ScanController` binds its methods in the
+  constructor (`this.postScan = this.postScan.bind(this)`), which
+  sidesteps the trap — keep that pattern when adding new handlers.

--- a/docs/plans/codebase-reorganization.md
+++ b/docs/plans/codebase-reorganization.md
@@ -1,21 +1,28 @@
-# EqualView — Codebase Reorganization
+# EqualView — Codebase Reorganization (post-mortem)
 
-**Status:** Phase 1 + Phase 2/3 (router) implemented · 2026-04-28
+**Status:** Complete · Phase 1 + Phase 3 router shipped 2026-04-28
+(PRs #38, #39, #40)
 **Companions:** [`project-roadmap.md`](project-roadmap.md),
 [`architecture-map.md`](architecture-map.md),
 [`axecore-integration-roadmap.md`](axecore-integration-roadmap.md)
 
-This document is the source of truth for **how the repo is organized**
-and what changed in the Phase 1 / Phase 2/3 reorganization. The
-roadmap (`project-roadmap.md`) tracks *what to build*; this doc tracks
-*where it lives* once built.
+This document is the historical record of the Phase 1 + Phase 3 reorg.
+It explains **what changed and why**. For:
+
+- **the current repo layout** → see the top-level
+  [`README.md`](../../README.md).
+- **the target architecture** → see
+  [`architecture-map.md`](architecture-map.md) §6.
+- **what's still to land** → see
+  [`architecture-map.md`](architecture-map.md) §6.6 and
+  [`project-roadmap.md`](project-roadmap.md).
 
 The original brainstorm lives at
 [`.kilo/plans/1777290694097-nimble-star.md`](../../.kilo/plans/1777290694097-nimble-star.md).
 
 ---
 
-## 1. Goals
+## 1. Goals (from when the work started)
 
 1. Each layer (route ⇄ controller ⇄ service ⇄ data) is a separate
    file with a single responsibility, so the real Puppeteer + axe-core
@@ -30,76 +37,9 @@ The original brainstorm lives at
 4. All four `npm test` / `npm run lint` / `npm run build` /
    `node --test` invocations are green at every milestone.
 
-## 2. Final layout
+## 2. What changed (and why)
 
-```
-equalview/
-├── backend/
-│   ├── index.js                    # Bootstrap: load .env, listen
-│   ├── app.js                      # Composition root (DI wiring)
-│   ├── routes/
-│   │   ├── index.js                # Mounts /api and /problems
-│   │   ├── scan.js                 # POST /api/scan, GET /api/scan-results
-│   │   └── problems.js             # GET /problems/:id
-│   ├── controllers/
-│   │   └── scanController.js       # Request/response, bound methods
-│   ├── services/
-│   │   ├── axeTransformer.js       # Pure: axe → ScanResult
-│   │   └── ssrfGuard.js            # Pure: URL allow/deny
-│   ├── data/
-│   │   └── mockScanResults.js      # Phase-1 fixture
-│   ├── tests/                      # node:test + supertest
-│   │   ├── health.test.js
-│   │   ├── scan.test.js
-│   │   ├── ssrfGuard.test.js
-│   │   └── axeTransformer.test.js
-│   ├── .env.example
-│   ├── Dockerfile                  # NEW — minimal node:22-alpine
-│   ├── README.md                   # NEW — run/test/env tables
-│   └── package.json                # test = `node --test tests/`
-│
-├── frontend/
-│   ├── src/
-│   │   ├── main.jsx                # React bootstrap
-│   │   ├── App.jsx                 # BrowserRouter + Routes
-│   │   ├── pages/
-│   │   │   ├── LandingPage.jsx     # was src/landingPage.jsx
-│   │   │   ├── ScanResultsPage.jsx # was src/ScanResults.jsx
-│   │   │   └── ProblemPage.jsx     # NEW — /problems/:id route
-│   │   ├── components/
-│   │   │   ├── ProblemSolutionPage.jsx
-│   │   │   ├── ProblemCategoryBox.jsx  # extracted from ScanResults
-│   │   │   └── WhatsGood.jsx           # extracted from ScanResults
-│   │   ├── hooks/
-│   │   │   ├── useScan.js          # NEW — encapsulates fetch state
-│   │   │   └── useProblem.js       # NEW — single-problem fetch
-│   │   ├── lib/
-│   │   │   └── apiClient.js        # NEW — only file that imports fetch
-│   │   ├── utils/
-│   │   │   └── urlValidator.js     # NEW — client-side URL sanity check
-│   │   ├── data/
-│   │   │   └── mockScanResults.js  # vitest-only fixture (unchanged)
-│   │   ├── styles/
-│   │   └── __tests__/
-│   ├── vite.config.js
-│   └── package.json
-│
-├── shared/
-│   └── types.js                    # NEW — JSDoc Problem / ScanResult / etc
-│
-├── docs/
-│   ├── plans/
-│   │   ├── project-roadmap.md
-│   │   ├── architecture-map.md
-│   │   ├── axecore-integration-roadmap.md
-│   │   └── codebase-reorganization.md   # THIS FILE
-│   └── guides/
-└── docker-compose.yml              # frontend + backend (new backend service)
-```
-
-## 3. What changed (and why)
-
-### 3.1 Backend (Phase 1 of [`project-roadmap.md`](project-roadmap.md))
+### 2.1 Backend (Phase 1 of [`project-roadmap.md`](project-roadmap.md))
 
 | Before                                   | After                                                         | Why                                                                                                                |
 | ---------------------------------------- | ------------------------------------------------------------- | ------------------------------------------------------------------------------------------------------------------ |
@@ -124,7 +64,7 @@ mountRoutes(app, { scanController });
 Tests get a fully-wired app via `buildApp()` and never bind a real
 port (see `backend/tests/scan.test.js`).
 
-### 3.2 Frontend (Phase 2/3 of [`project-roadmap.md`](project-roadmap.md))
+### 2.2 Frontend (Phase 3 of [`project-roadmap.md`](project-roadmap.md))
 
 | Before                                      | After                                                | Why                                                                                                  |
 | ------------------------------------------- | ---------------------------------------------------- | ---------------------------------------------------------------------------------------------------- |
@@ -146,14 +86,14 @@ the effect and only call `setState` inside async resolutions, to
 satisfy React 19's `react-hooks/set-state-in-effect` rule. The
 returned shape is always `{ data, loading, error }`.
 
-### 3.3 Shared
+### 2.3 Shared
 
 `shared/types.js` holds JSDoc typedefs (`Problem`, `ScanResult`,
 `Impact`, planned `User`/`StoredScan`). Backend and frontend reference
 the same definitions via `@typedef {import(...)}` so the wire shape
 is documented once.
 
-## 4. Verification
+## 3. Verification
 
 | Command                              | Result   |
 | ------------------------------------ | -------- |
@@ -163,35 +103,8 @@ is documented once.
 | `cd frontend && npm run build`       | ok       |
 | `docker compose config`              | valid    |
 
-## 5. What's next
+## 4. What's next
 
-These are tracked in [`project-roadmap.md`](project-roadmap.md) — this
-doc just notes the slot they land in:
-
-- **Phase 2 — real scanner**: replace the controller's
-  `mockScanResults` with `ScanRunner` (lives in `backend/services/`).
-  The transformer, ssrf guard, and route layout are already in place.
-- **Phase 3 — UX polish**: severity badges, WCAG tag filters, "Needs
-  manual review" bucket. Each becomes a new prop on
-  `ProblemCategoryBox` and a new field on the JSDoc `Problem` type.
-- **Phase 5 — accounts**: `backend/db/`, `backend/middleware/`,
-  `services/authService.js`, plus `frontend/src/pages/LoginPage.jsx`,
-  `MyScansPage.jsx`, and `hooks/useAuth.js` — slots already reserved
-  in [`architecture-map.md`](architecture-map.md) §6.3 / §6.4.
-
-## 6. Migration mapping (today → eventual)
-
-This is the same table as
-[`architecture-map.md`](architecture-map.md) §6.6, marked up with
-what now exists:
-
-| Old                                                       | New                                                                | Status |
-| --------------------------------------------------------- | ------------------------------------------------------------------ | ------ |
-| inline `app.post('/api/scan')`                            | `routes/scan.js` + `ScanController.postScan`                       | ✅ done |
-| `mockScanResults` import in server                        | injected into `ScanController` via `app.js`                        | ✅ done |
-| `cors({ origin: 'http://localhost:5173' })`               | `cors({ origin: process.env.FRONTEND_ORIGIN })`                    | ✅ done |
-| `fetch('/api/scan-results…')` in `ScanResults.jsx`        | `useScan(url)` → `apiClient.getScanResults(url)`                   | ✅ done |
-| `selectedProblem` only in component state                 | `/problems/:id` route + `useProblem(id)` hook                      | ✅ done |
-| `window.location.href = …` in landing page                | `useNavigate()`                                                    | ✅ done |
-| Phase-2 `ScanRunner`                                      | `backend/services/scanRunner.js` + Puppeteer + axe                 | ⏳ Phase 2 |
-| Phase-5 auth                                              | `backend/services/authService.js`, `db/`, `middleware/requireAuth` | ⏳ Phase 5 |
+Tracked in [`project-roadmap.md`](project-roadmap.md); the slot each
+piece lands in is captured in
+[`architecture-map.md`](architecture-map.md) §6.6.

--- a/docs/plans/project-roadmap.md
+++ b/docs/plans/project-roadmap.md
@@ -83,38 +83,39 @@ data and Deque University owns the long-form remediation content.
 3. Decisions get recorded here or in a sub-roadmap, not in chat.
 4. Tests come in alongside the code that needs them, not "later".
 
-## Open decisions (lock in before they block a phase)
+## Decisions
 
-These gate specific phases. Until resolved, leave the corresponding
-checkboxes unchecked.
+### Resolved
 
-- [ ] **Frontend routing**: keep `window.location.pathname` switch in
-      `App.jsx` or adopt `react-router`? A real scan should produce a
-      shareable results URL, which favors a router. (Blocks Phase 3.)
-- [ ] **Scan API shape**: now that we know axe's native shape (above),
-      pick one:
-      - **A.** Pass through axe's four arrays largely as-is and let the
-        frontend group/sort. Flexible, less backend logic, but the
-        response is large.
+- **Frontend routing** → `react-router-dom` v7 (`BrowserRouter` +
+  `Routes` in `src/App.jsx`, pages in `src/pages/`). Shipped in PR #40.
+- **Backend test runner** → `node:test` + `supertest` via
+  `node --test tests/`. No extra dev deps beyond `supertest`. Shipped
+  in PR #38.
+- **SSRF policy** → block non-`http(s)` schemes (`file:`, `data:`,
+  `javascript:`, …), `localhost`, and RFC1918 / loopback IPs.
+  Implemented in `backend/services/ssrfGuard.js`. Shipped in PR #38.
+
+### Still open
+
+- [ ] **Scan API shape** (blocks Phase 2). Pick one:
+      - **A.** Pass through axe's four arrays as-is and let the
+        frontend group/sort. Flexible, less backend logic, larger
+        response.
       - **B.** Keep the current bucketed shape
         (`{ problems: { visualAccessibility, structureAndSemantics, multimedia }, whatsGood }`)
         and map axe `tags` → buckets in
         `services/axeTransformer.js`. Smaller payload, opinionated UI,
         but loses `incomplete` and per-node detail unless we extend it.
       - **C.** Hybrid: bucketed summary **plus** the raw axe arrays
-        under `raw`, so the UI can drill in. (Blocks Phase 2.)
-- [ ] **Sync vs async scan**: does `POST /api/scan` block, or return a
-      `jobId` to poll? Default: sync with a generous timeout for Phase
-      2; revisit in Phase 5. (Blocks Phase 2.)
-- [ ] **SSRF policy**: confirm the URL allow/deny rules — block
-      `file://`, `data:`, private IP ranges, `localhost`, and require
-      `http(s)`. (Blocks Phase 2.)
-- [ ] **Backend test runner**: Jest + supertest (matches the existing
-      guide) vs Vitest. Default: Jest + supertest. (Blocks Phase 1.)
+        under `raw`, so the UI can drill in.
+- [ ] **Sync vs async scan** (blocks Phase 2). Does `POST /api/scan`
+      block, or return a `jobId` to poll? Default: sync with a generous
+      timeout for Phase 2; revisit in Phase 6.
 
 ---
 
-## Phase 0 — Housekeeping (in flight)
+## Phase 0 — Housekeeping (complete)
 
 Goal: a clean repo that an outsider can read in 10 minutes.
 
@@ -146,10 +147,11 @@ Goal: a clean repo that an outsider can read in 10 minutes.
   - [x] Confirm `frontend/`'s `react-router` / `react-router-dom`
         deps stay (already installed; unblocks the Phase 3 routing
         work without re-running `npm install`).
-- [ ] Open PR for the cleanup + this roadmap update and merge.
+- [x] Open PR for the cleanup + this roadmap update and merge
+      (PRs #36, #37).
 
 **Done when:** the cleanup PR is merged into `main` and
-`frontend/src/__tests__/` is the canonical test folder.
+`frontend/src/__tests__/` is the canonical test folder. ✅
 
 ### 🎓 Intern tasks after Phase 0
 
@@ -174,34 +176,38 @@ PR.
 
 ---
 
-## Phase 1 — Backend foundations for a real scanner
+## Phase 1 — Backend foundations for a real scanner (complete)
 
 Goal: structure the backend so a real scanner can drop in without
 rewriting routing and so we can write tests for it.
 
-Depends on: open decision *Backend test runner*.
+Shipped in PR #38. See
+[`codebase-reorganization.md`](codebase-reorganization.md) for the
+before/after detail.
 
-- [ ] Split `backend/index.js`: move route handlers into
+- [x] Split `backend/index.js`: move route handlers into
       `backend/routes/scan.js` (`express.Router`).
-- [ ] Add `backend/controllers/scanController.js` that today still
+- [x] Add `backend/controllers/scanController.js` that today still
       returns `mockScanResults` — same response, just relocated. Bind
       handlers correctly (avoid the known `this`-binding bug
       documented in
       [`axecore-integration.md`](../guides/axecore-integration.md)).
-- [ ] Add `backend/services/axeTransformer.js` as a stub with a typed
+- [x] Add `backend/services/axeTransformer.js` as a stub with a typed
       input → output contract derived from the axe shape above. Cover
       it with a unit test using a captured axe payload as a fixture.
-- [ ] Wire up the chosen test runner (`npm test` in `backend/`) and
-      add one supertest hitting `/health`.
-- [ ] Add `backend/.env.example` documenting `PORT` and
+- [x] Wire up the chosen test runner (`npm test` in `backend/`) and
+      add one supertest hitting `/health`. (Chose `node:test` +
+      `supertest`; see Resolved decisions above.)
+- [x] Add `backend/.env.example` documenting `PORT` and
       `FRONTEND_ORIGIN`; make `index.js` read `FRONTEND_ORIGIN` for
       CORS with a default of `http://localhost:5173`.
-- [ ] Add `backend/Dockerfile` and update `docker-compose.yml` to
+- [x] Add `backend/Dockerfile` and update `docker-compose.yml` to
       build it (no Puppeteer system deps yet — those land in Phase 2).
 
-**Done when:** `npm test` passes in `backend/`, `docker compose up`
-still serves the same JSON, and the file layout matches the "target"
-section of [`axecore-integration-roadmap.md`](axecore-integration-roadmap.md).
+**Done when:** `npm test` passes in `backend/` (17 / 17),
+`docker compose up` still serves the same JSON, and the file layout
+matches the "target" section of
+[`axecore-integration-roadmap.md`](axecore-integration-roadmap.md). ✅
 
 ### 🎓 Intern tasks after Phase 1
 
@@ -234,8 +240,11 @@ this phase is the high-level checkpoint.
 - [ ] `services/axeTransformer.js` implements the chosen response
       shape (Option A/B/C from the open decision). At minimum it must
       preserve, per violation: `id`, `help`, `helpUrl`, `impact`,
-      `tags`, and `nodes[].{html, target, failureSummary}`.
-- [ ] SSRF guard implemented and tested.
+      `tags`, and `nodes[].{html, target, failureSummary}`. (Stub +
+      contract shipped in PR #38; body still to write.)
+- [x] SSRF guard implemented and tested.
+      (`backend/services/ssrfGuard.js`, wired into both
+      `POST /api/scan` and `GET /api/scan-results`; PR #38.)
 - [ ] One end-to-end smoke test against a known-bad fixture page and
       a known-clean fixture page.
 - [ ] `mockScanResults.js` is only imported by tests, not by the
@@ -258,23 +267,25 @@ offending element(s) — for a real URL submitted from the landing page.
 
 ---
 
-## Phase 3 — UX upgrades
+## Phase 3 — UX upgrades (router shipped; data-driven UX pending Phase 2)
 
 Goal: the app feels like a product, not a demo.
 
-Depends on: open decision *Frontend routing*.
+The routing + page-component scaffolding shipped in PR #40 — the rest
+needs real axe data from Phase 2 before it can be wired up.
 
-- [ ] Resolve the routing question; if `react-router`, migrate
-      `App.jsx` and remove the pathname switch.
-- [ ] Replace the landing-page `setTimeout` with real navigation tied
-      to scan submission state (loading → results, with progress).
+- [x] Resolve the routing question; migrate `App.jsx` and remove the
+      pathname switch. (`react-router-dom` v7; PR #40.)
+- [x] Replace the landing-page `setTimeout` with real navigation tied
+      to scan submission state. (`useNavigate()` + `useScan` hook;
+      PR #40.)
 - [ ] Surface axe-core `incomplete` results as a "Needs manual
-      review" bucket.
+      review" bucket. (Needs Phase 2.)
 - [ ] Each problem links to its axe `helpUrl`; severity rendered as
-      a colored badge driven by `impact`.
+      a colored badge driven by `impact`. (Needs Phase 2.)
 - [ ] Sort violations by `impact` (`critical` → `serious` →
       `moderate` → `minor`); allow filtering by WCAG `tags`
-      (`wcag2a`, `wcag2aa`, `best-practice`).
+      (`wcag2a`, `wcag2aa`, `best-practice`). (Needs Phase 2.)
 - [ ] Pass an a11y audit on our own pages — run axe against
       `http://localhost:5173`.
 
@@ -408,6 +419,13 @@ These don't belong to a single phase — pick them up opportunistically.
 
 ## Change log for this roadmap
 
+- _2026-04-28_ — Post-reorg refresh: marked Phase 0 (cleanup PR),
+  Phase 1 (backend reorg, PR #38), and the routing/scaffolding parts
+  of Phase 3 (PR #40) as shipped. Split "Open decisions" into
+  "Resolved" (frontend routing, backend test runner, SSRF policy) and
+  "Still open" (scan API shape, sync vs async). Ticked the Phase 2
+  SSRF-guard line — the guard is implemented and wired into
+  `scanController` even though the real scan body is still pending.
 - _2026-04-27_ — Phase 0 housekeeping followup: removed dead UI from
   `landingPage.jsx` (placeholder Problems / What's Good sections that
   never render once the page redirects) and the no-op "Download PDF


### PR DESCRIPTION
…tent

After PRs #38 (backend reorg), #39 (docs/ux+code map), and #40 (frontend router) landed on main, several docs were stale or redundant. This pass:

project-roadmap.md
- Phase 0 marked complete; Phase 1 ticked end-to-end (PR #38) with links to the shipped controller/routes/services/Dockerfile/.env.
- Phase 3 routing + landing-navigation ticked (PR #40); the data-driven UX items (badges, WCAG filters, 'Needs review' bucket) remain unchecked since they need real axe data from Phase 2.
- Phase 2 SSRF-guard line ticked: the guard is implemented and wired into ScanController, even though the real Puppeteer body is pending.
- 'Open decisions' split into 'Resolved' (frontend routing → react- router-dom v7; backend test runner → node:test+supertest; SSRF policy → ssrfGuard.js) and 'Still open' (scan API shape, sync vs async). Old anchor refs updated to #still-open.
- Change-log entry added for 2026-04-28.

architecture-map.md
- §2.1/§2.2/§2.3 'current' wording updated: useNavigate, useScan/ useProblem hooks, apiClient, urlValidator, real /problems/:id route.
- §4.1 frontend tree replaced with the live pages/, hooks/, lib/, utils/ layout; §4.2 backend tree shows shipped routes/, app.js, ssrfGuard, README.md, Dockerfile, .env.example.
- §5 'Where to look when X breaks' file paths point at current files (pages/, hooks/, routes/, services/) plus new rows for SSRF rejection and /problems/:id deep-link 404s.
- §6.2 'shared/types.js' note marked shipped (PR #38).
- §6.5 composition-root pseudo-code: shipped lines marked shipped, Phase-2 and Phase-5 lines kept as forward-looking pseudo-code.
- §6.6 rewritten — past-tense today→eventual table replaced with a short 'what shipped in Phase 1+3' paragraph plus a forward-looking table of slots still to land in Phase 2 / 3 / 5.

axecore-integration-roadmap.md
- Status changed from 'Not started' to 'Phase 1 scaffolding shipped (PR #38); Phase 2 not started'.
- 'Constraints/decisions' block replaced with a one-paragraph pointer at project-roadmap.md#decisions; resolved decisions removed from this doc to avoid drift.
- File layout retitled '(current)' and refreshed to match disk.
- Phase 1 checklist: shipped items ticked with PR refs, items that still need Phase-2 wiring (puppeteer install, transformer body, smoke tests) left unchecked.
- Risks section: CORS risk struck through (now config-driven), this-binding risk updated to note the constructor-bind pattern the shipped controller uses.

codebase-reorganization.md
- Slimmed from a near-duplicate of architecture-map §6.6 + README to a focused post-mortem: kept §1 goals, §3 before/after rationale tables, §4 verification, §5 what's-next pointer.
- Dropped §2 'Final layout' (lives in README.md) and §6 'Migration mapping' (was explicitly the same table as architecture-map §6.6).
- Banner at the top points at README, architecture-map §6, and project-roadmap for current/future state.

docs/README.md
- Updated codebase-reorganization.md description to reflect its new role as a historical post-mortem, with pointers to where the live layout and architecture target now live.

Open questions for review (not addressed by this PR):
- Should codebase-reorganization.md eventually be archived under a docs/plans/done/ subfolder once Phase 2 lands? Left in place for now.
- docs/guides/axecore-integration.md still references the pre-reorg filename frontend/src/landingPage.jsx in one place. Left untouched because that whole guide will be rewritten when Phase 2 wires real Puppeteer.

No code changes, no test changes.