### PR TITLE
assets: add standalone EqualView brand SVGs (logomark + logotype)

### DIFF
--- a/frontend/src/assets/brand/equalview-logomark-mono.svg
+++ b/frontend/src/assets/brand/equalview-logomark-mono.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="EqualView">
+  <rect x="0.75" y="0.75" width="38.5" height="38.5" rx="10.25" fill="none" stroke="currentColor" stroke-width="1.5"/>
+  <rect x="9" y="15.5" width="22" height="3.6" rx="1.8" fill="currentColor"/>
+  <rect x="9" y="21.9" width="14" height="3.6" rx="1.8" fill="currentColor"/>
+  <circle cx="27" cy="23.7" r="2.1" fill="currentColor"/>
+</svg>

--- a/frontend/src/assets/brand/equalview-logomark.svg
+++ b/frontend/src/assets/brand/equalview-logomark.svg
@@ -1,0 +1,6 @@
+<svg width="40" height="40" viewBox="0 0 40 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="EqualView">
+  <rect width="40" height="40" rx="11" fill="#2563d6"/>
+  <rect x="9" y="15.5" width="22" height="3.6" rx="1.8" fill="#fff"/>
+  <rect x="9" y="21.9" width="14" height="3.6" rx="1.8" fill="#fff"/>
+  <circle cx="27" cy="23.7" r="2.1" fill="#fff"/>
+</svg>

--- a/frontend/src/assets/brand/equalview-logotype.svg
+++ b/frontend/src/assets/brand/equalview-logotype.svg
@@ -1,0 +1,11 @@
+<svg width="210" height="40" viewBox="0 0 210 40" fill="none" xmlns="http://www.w3.org/2000/svg" role="img" aria-label="EqualView">
+  <!-- mark -->
+  <rect width="40" height="40" rx="11" fill="#2563d6"/>
+  <rect x="9" y="15.5" width="22" height="3.6" rx="1.8" fill="#fff"/>
+  <rect x="9" y="21.9" width="14" height="3.6" rx="1.8" fill="#fff"/>
+  <circle cx="27" cy="23.7" r="2.1" fill="#fff"/>
+  <!-- wordmark: Public Sans Bold, "equal" ink + "view" accent -->
+  <text x="53.6" y="20" font-family="'Public Sans', system-ui, -apple-system, 'Segoe UI', sans-serif" font-size="28.8" font-weight="700" letter-spacing="-0.576" dominant-baseline="central">
+    <tspan fill="#0a0e13">equal</tspan><tspan fill="#2563d6">view</tspan>
+  </text>
+</svg>


### PR DESCRIPTION
Extract the logo from the Logo.jsx lockup into reusable static SVGs:
- equalview-logomark.svg  - brand mark, blue tile (#2563d6)
- equalview-logomark-mono.svg - single-color mark via currentColor
- equalview-logotype.svg - full mark + wordmark lockup