### PR TITLE
docs: bring-your-own-storage portable account (auth/storage redesign)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -41,3 +41,77 @@ This project is indexed by GitNexus as **equalview** (754 symbols, 971 relations
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->
+
+# EqualView — Architecture & Conventions
+
+EqualView is an accessibility scanner: paste a URL, get a categorized,
+human-readable accessibility report. Two halves, one wire contract.
+
+- **Backend** (`backend/`, Node + Express) is dumb about presentation. Layers,
+  outer→inner: `routes/` (URLs + verbs) → `controllers/` (HTTP req/res, classes
+  with constructor-bound methods) → `services/` (the brain). `app.js` is the
+  **composition root** — the one place concrete classes are constructed and wired;
+  everything else takes deps as arguments so layers are unit-testable without a DI
+  framework. Pure modules (`axeTransformer`, `ssrfGuard`) take input → return
+  output, no side effects. Stateful things are classes (`ScanRunner`, future
+  `BrowserPool`).
+- **Frontend** (`frontend/`, React + Vite) is dumb about scanning. Pages =
+  functional components in `views/`; side effects live in `hooks/`;
+  `lib/apiClient.js` is the **only** file that imports `fetch`; `utils/urlValidator.js`
+  validates input. Talks to the backend through `/api/*` (Vite proxies in dev).
+- **Shared contract**: `shared/types.js` holds JSDoc `@typedef`s (`ScanResult`,
+  `Violation`, …) imported by both sides — the wire format is the only contract
+  that matters.
+- Deeper detail: [`docs/plans/architecture-map.md`](docs/plans/architecture-map.md)
+  (§6 code architecture) and [`README.md`](README.md) (current layout).
+
+## Accounts & storage — bring-your-own-storage (portable account)
+
+EqualView keeps **no database of its own**. A signed-in user's entire account
+(profile, settings, saved scans) lives in **storage they already own**: one
+**GitHub repository** or one **Google Drive folder**. GitHub/Google OAuth is used
+only to *identify* the user and get an API token; the user-owned store is the
+source of truth. This is what makes the product cheap to offer to everyone — no
+per-user hosting, no lock-in; the account is portable across devices.
+
+The connection UX is **browse → select → validate → load-or-init**:
+
+1. User connects GitHub or Google (OAuth).
+2. They **see the repos/folders they already have** and **select one**
+   (GitHub: backend lists repos; Google: client-side **Google Picker**, because
+   `drive.file` cannot browse existing folders).
+3. EqualView runs a **fit-check** (`POST /api/auth/storage/validate`) — does this
+   storage hold a valid EqualView account store? → `loadable` / `initializable` /
+   `unrelated` / `incompatible` / `invalid` (+ capabilities).
+4. EqualView **loads** the existing account back, or **initializes** the store.
+
+On-disk contract (the "data needed to load back the account"): a root
+`equalview.json` manifest + a `scans/` folder (`index.json` cache + one immutable
+`<scanId>_<host>.json` per scan). Scan files are truth; `index.json` and
+`scanCount` are rebuildable caches.
+
+When working on auth/storage, treat these as the source of truth and keep them in
+sync with the code:
+
+- [`docs/guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md`](docs/guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md)
+  — auth flow, endpoints, scopes, frontend design.
+- [`docs/guides/auth_storage_guide/accountStorageContract.md`](docs/guides/auth_storage_guide/accountStorageContract.md)
+  — manifest + scans layout + fit-check + concurrency rules.
+- [`docs/guides/auth_storage_guide/TODO.md`](docs/guides/auth_storage_guide/TODO.md)
+  — implementation checklist.
+
+Non-negotiables for this subsystem:
+
+- **No tokens/secrets in the store.** OAuth tokens are encrypted at rest in the
+  session (AES-256-GCM), never written to the repo/folder.
+- **Possession-based identity by default** — whoever can read/write the store can
+  load the account; treat the storage ACL as the account ACL. Record stable
+  provider ids (repo node id / Drive folder id / owner id), not names.
+- **Concurrency & partial writes are expected** — multiple devices and
+  collaborators touch the store. Scan files are immutable; caches reconcile on
+  load; GitHub writes use blob `sha`, Drive writes use generation/ETag.
+- **Scope tradeoffs are real and must be disclosed in the UI**, not just docs
+  (GitHub OAuth `repo` is all-or-nothing; Google browsing needs Picker or
+  `drive.metadata.readonly`).
+- This **supersedes** the Postgres + JWT sketch in the Phase 5 roadmap — there is
+  no project DB.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,88 @@
+# CHANGELOG — Auth & Storage Design Revision
+
+## Samuel's Design (committed `44f78f39`, June 29)
+
+**Model:** OAuth → attach a storage location → write scan reports to it.
+
+- Auth is for identity; storage is for saving scan outputs.
+- Fit-check does not exist. The user picks a name (typed or from a hard-coded
+  `existing` list in `placeholders.js`) and the backend creates a new repo/folder
+  or blindly reuses it.
+- Google Drive: backend lists existing folders via server-side API calls.
+- GitHub scopes: `repo` (all-or-nothing) or `public_repo`, noted in passing.
+- Security model: standard session-based OAuth with encrypted tokens.
+- Storage content: the design says "scan results saved to repo/folder" but
+  doesn't define an on-disk contract — no manifest, no layout rules, no
+  concurrency handling.
+- The TODO mentions `scans/<hostname>_{timestamp}.json` naming but nothing
+  about accounts, settings, or account rehydration.
+- Phase 5 roadmap still references Postgres + JWT in parallel (the DB and the
+  user-owned store coexist without reconciliation).
+- Frontend: placeholder flow (`PLACEHOLDER_USER`, `PLACEHOLDER_SAVED_SCANS`,
+  hard-wired `existing` arrays). ConnectView is "pick a name from a dropdown
+  you can't edit."
+
+**What it was good at:** clean passport wiring, clear endpoint tables, solid
+token-encryption pattern, honest about acceptance criteria. A sound "auth +
+write reports" doc.
+
+## Your Revision (June 30)
+
+**Model:** OAuth → browse real storage → validate fit → **load the whole
+account back** or init a new one. The user's repo/folder *is* the account.
+
+- Auth is only an API-token handshake; the store holds everything.
+- **Fit-check** (`POST /api/auth/storage/validate`) reads the storage and
+  returns `loadable | initializable | unrelated | incompatible | invalid` with
+  capabilities. This is the UX you described: "does this fit with the data
+  needed to load back the account?"
+- Google Drive: uses **Google Picker** (client-side), because `drive.file`
+  cannot browse existing folders. This was a real gap in Samuel's design.
+- GitHub scopes: documented `public_repo` vs `repo` tradeoff, plus a
+  recommendation for **GitHub App** (per-repo `Contents: read/write`) as the
+  least-privilege path.
+- **`accountStorageContract.md`** (new) — the authoritative on-disk spec:
+  `equalview.json` manifest with `accountId`, `storage.ownerId`, `settings`,
+  `summary`; `scans/index.json` cache; immutable scan files named
+  `<scanId>_<host>.json`. Every field has a reason.
+- **Concurrency & partial-write model:** optimistic concurrency via blob `sha`
+  (GitHub) / generation ETags (Drive); scan files are truth, index is a
+  rebuildable cache; load-time reconcile heals drift; validate→init races are
+  guarded by conditional create.
+- **Identity model:** possession-based by default (storage ACL = account ACL).
+  Records stable provider ids (node id, folder id, owner id), not names/emails.
+  Subject-bound mode is an optional future policy.
+- **Non-negotiables** codified: no tokens in store, no project DB, scope
+  tradeoffs disclosed in UI, account is portable across devices.
+- **Scope tradeoffs are surfaced in the picker UI**, not buried in docs.
+  The `/storages` endpoint and the fit-check response give the frontend enough
+  to render informed choices.
+- Agent files (`AGENTS.md`, `CLAUDE.md`) and `docs/README.md` are updated so
+  anyone working on the codebase sees the architecture immediately.
+- The **Phase 5 roadmap is superseded** — there is no project database.
+  Supersession is explicit in every doc.
+
+## What's Gained in Vision
+
+| Dimension | Samuel's lens | Your lens |
+|---|---|---|
+| **What storage is** | A place to dump scan files | The user's portable account — settings, identity, and history travel with it |
+| **Selection UX** | Type a name / pick from a `placeholders.js` list | Browse real repos → validate → see scan count → one-click load or init |
+| **Fit-check** | Not present | Central UX primitive: 5 statuses + reasons + capabilities |
+| **Browsing reality** | Assumes backend can list Drive folders | Recognizes `drive.file` cannot browse → Picker is mandatory |
+| **GitHub scope** | Noted but undecided | Recommended GitHub App for per-repo least privilege; disclosed `repo` tradeoff |
+| **On-disk contract** | "Save scans to a folder" — no structure | Full manifest + index + immutable scan files with versioning, concurrency, drift repair |
+| **Concurrent access** | Not addressed | Built-in: optimistic ops, load-time reconcile, caches vs truth, race-guarded init |
+| **Identity** | OAuth subject is the user | Possession-based default — storage access IS account access; optional subject binding |
+| **Mobile / cross-device** | Not scoped | "Pick the same storage on any device" is the whole point |
+| **Cost model** | Not articulated | No per-user hosting, no DB, no lock-in → cheap to offer to everyone |
+| **DB in Phase 5** | Postgres + JWT in parallel | **No project DB ever** — portable store *is* the DB; supersession is explicit |
+| **Implementation guide** | 2 files (design + TODO) | 3 files (+ on-disk contract) + agent files + docs index; each file has a single responsibility |
+
+The core shift: Samuel treated storage as a **sink** for scan output. You treat
+it as the **source of truth for a user's entire relationship with the product**.
+Everything — endpoints, fit-check, concurrency rules, scope disclosure, the
+Picker requirement — flows from that single framing change. It makes the
+product fundamentally cheaper to run (zero server state per user), more
+portable (your account is a repo/folder), and more honest about what each
+provider's scope actually lets you do.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -41,3 +41,77 @@ This project is indexed by GitNexus as **equalview** (754 symbols, 971 relations
 | Index, status, clean, wiki CLI commands | `.claude/skills/gitnexus/gitnexus-cli/SKILL.md` |
 
 <!-- gitnexus:end -->
+
+# EqualView — Architecture & Conventions
+
+EqualView is an accessibility scanner: paste a URL, get a categorized,
+human-readable accessibility report. Two halves, one wire contract.
+
+- **Backend** (`backend/`, Node + Express) is dumb about presentation. Layers,
+  outer→inner: `routes/` (URLs + verbs) → `controllers/` (HTTP req/res, classes
+  with constructor-bound methods) → `services/` (the brain). `app.js` is the
+  **composition root** — the one place concrete classes are constructed and wired;
+  everything else takes deps as arguments so layers are unit-testable without a DI
+  framework. Pure modules (`axeTransformer`, `ssrfGuard`) take input → return
+  output, no side effects. Stateful things are classes (`ScanRunner`, future
+  `BrowserPool`).
+- **Frontend** (`frontend/`, React + Vite) is dumb about scanning. Pages =
+  functional components in `views/`; side effects live in `hooks/`;
+  `lib/apiClient.js` is the **only** file that imports `fetch`; `utils/urlValidator.js`
+  validates input. Talks to the backend through `/api/*` (Vite proxies in dev).
+- **Shared contract**: `shared/types.js` holds JSDoc `@typedef`s (`ScanResult`,
+  `Violation`, …) imported by both sides — the wire format is the only contract
+  that matters.
+- Deeper detail: [`docs/plans/architecture-map.md`](docs/plans/architecture-map.md)
+  (§6 code architecture) and [`README.md`](README.md) (current layout).
+
+## Accounts & storage — bring-your-own-storage (portable account)
+
+EqualView keeps **no database of its own**. A signed-in user's entire account
+(profile, settings, saved scans) lives in **storage they already own**: one
+**GitHub repository** or one **Google Drive folder**. GitHub/Google OAuth is used
+only to *identify* the user and get an API token; the user-owned store is the
+source of truth. This is what makes the product cheap to offer to everyone — no
+per-user hosting, no lock-in; the account is portable across devices.
+
+The connection UX is **browse → select → validate → load-or-init**:
+
+1. User connects GitHub or Google (OAuth).
+2. They **see the repos/folders they already have** and **select one**
+   (GitHub: backend lists repos; Google: client-side **Google Picker**, because
+   `drive.file` cannot browse existing folders).
+3. EqualView runs a **fit-check** (`POST /api/auth/storage/validate`) — does this
+   storage hold a valid EqualView account store? → `loadable` / `initializable` /
+   `unrelated` / `incompatible` / `invalid` (+ capabilities).
+4. EqualView **loads** the existing account back, or **initializes** the store.
+
+On-disk contract (the "data needed to load back the account"): a root
+`equalview.json` manifest + a `scans/` folder (`index.json` cache + one immutable
+`<scanId>_<host>.json` per scan). Scan files are truth; `index.json` and
+`scanCount` are rebuildable caches.
+
+When working on auth/storage, treat these as the source of truth and keep them in
+sync with the code:
+
+- [`docs/guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md`](docs/guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md)
+  — auth flow, endpoints, scopes, frontend design.
+- [`docs/guides/auth_storage_guide/accountStorageContract.md`](docs/guides/auth_storage_guide/accountStorageContract.md)
+  — manifest + scans layout + fit-check + concurrency rules.
+- [`docs/guides/auth_storage_guide/TODO.md`](docs/guides/auth_storage_guide/TODO.md)
+  — implementation checklist.
+
+Non-negotiables for this subsystem:
+
+- **No tokens/secrets in the store.** OAuth tokens are encrypted at rest in the
+  session (AES-256-GCM), never written to the repo/folder.
+- **Possession-based identity by default** — whoever can read/write the store can
+  load the account; treat the storage ACL as the account ACL. Record stable
+  provider ids (repo node id / Drive folder id / owner id), not names.
+- **Concurrency & partial writes are expected** — multiple devices and
+  collaborators touch the store. Scan files are immutable; caches reconcile on
+  load; GitHub writes use blob `sha`, Drive writes use generation/ETag.
+- **Scope tradeoffs are real and must be disclosed in the UI**, not just docs
+  (GitHub OAuth `repo` is all-or-nothing; Google browsing needs Picker or
+  `drive.metadata.readonly`).
+- This **supersedes** the Postgres + JWT sketch in the Phase 5 roadmap — there is
+  no project DB.

--- a/docs/README.md
+++ b/docs/README.md
@@ -25,6 +25,11 @@ Stable, "how do I do X" content. Update when the answer changes.
 - [`guides/thinking-in-architecture.md`](guides/thinking-in-architecture.md)
   — 5-minute intern primer on the layered model, with each open GitHub
   issue mapped to "which layer does this change live in?"
+- [`guides/auth_storage_guide/`](guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md)
+  — GitHub/Google sign-in + the bring-your-own-storage portable account
+  (browse → select → validate → load/init). Design doc, on-disk
+  [`accountStorageContract.md`](guides/auth_storage_guide/accountStorageContract.md),
+  and an implementation [`TODO.md`](guides/auth_storage_guide/TODO.md).
 
 ## Plans
 

--- a/docs/guides/auth_storage_guide/TODO.md
+++ b/docs/guides/auth_storage_guide/TODO.md
@@ -1,7 +1,24 @@
-# Implementation TODO — GitHub/Google Auth & Storage
+# Implementation TODO — GitHub/Google Auth & Portable Storage
 
-> Checklist for implementing the design in `githubGoogleAuthStorageImplementation.md`.
-> Each item should be verified against the actual codebase before marking complete.
+> Checklist for the design in
+> [`githubGoogleAuthStorageImplementation.md`](githubGoogleAuthStorageImplementation.md)
+> and the on-disk contract in
+> [`accountStorageContract.md`](accountStorageContract.md).
+> Verify each item against the actual code before ticking it.
+>
+> **Model in one line:** the user's GitHub repo / Drive folder *is* the account.
+> Flow is **browse → select → validate (fit-check) → load or init**. No project DB.
+
+---
+
+## Phase 0: Decisions to lock before coding
+
+- [ ] **GitHub**: classic OAuth App (`repo` = broad) **or** GitHub App
+      (per-repo `Contents:rw` + `Metadata:r`)? Pick one; it changes the picker UX.
+- [ ] **Google**: Google Picker (`drive.file`, recommended) **or** app-rendered
+      browse (`drive.metadata.readonly`)? Pick one; document the privacy cost.
+- [ ] **Identity**: possession-based (default) vs. subject-bound load. Default =
+      possession-based; record `storage.ownerId` regardless.
 
 ---
 
@@ -12,125 +29,143 @@
 - [ ] `npm install --save-dev @types/express-session @types/passport @types/passport-github2 @types/passport-google-oauth20`
 
 ### Environment
-- [ ] Add required vars to `.env.example` and document in `backend/README.md`
+- [ ] Add vars to `.env.example` (`SESSION_SECRET`, GitHub/Google client id+secret,
+      redirect URIs, `GOOGLE_PICKER_API_KEY`, `ENCRYPTION_KEY`) and document in `backend/README.md`
 - [ ] Generate `ENCRYPTION_KEY` with `openssl rand -base64 32`
 
 ### Auth Service (`backend/services/authService.js`)
-- [ ] Create file with Passport strategies (GitHub, Google)
-- [ ] Implement AES-256-GCM encrypt/decrypt using `ENCRYPTION_KEY`
-- [ ] Export `middleware()` returning `[session(), passport.initialize(), passport.session()]`
-- [ ] Export `getGitHubClient(user)` → authenticated Octokit
-- [ ] Export `getGoogleDriveClient(user)` → authenticated Google Drive client (OAuth2 with access_token)
-- [ ] Export `refreshGoogleToken(user)` for token refresh
-- [ ] **Stub** `deserializeUser` with `// TODO: load full user from DB`
+- [ ] Passport strategies (GitHub, Google) + session middleware
+- [ ] AES-256-GCM encrypt/decrypt using `ENCRYPTION_KEY`
+- [ ] `middleware()` → `[session(), passport.initialize(), passport.session()]`
+- [ ] `getGitHubClient(user)` → authenticated Octokit
+- [ ] `getGoogleDriveClient(user)` → OAuth2 + `setCredentials({ access_token })`
+- [ ] `refreshGoogleToken(user)`
+- [ ] `clientsFor(user)` helper → `{ githubClient?, driveClient? }` for routes/controller
+- [ ] `deserializeUser` returns the session payload (identity + encrypted tokens +
+      attached `storage`); **no user DB** in this model
 
-### Storage Service (`backend/services/storageService.js`)
-- [ ] Create file with GitHub operations:
-  - [ ] `createGitHubRepo(githubClient, repoName, private)`
-  - [ ] `createGitHubFile(githubClient, owner, repo, path, content, branch)`
-- [ ] Create file with Google Drive operations:
-  - [ ] `createGoogleDriveFolder(driveClient, folderName, parentId)`
-  - [ ] `uploadToGoogleDrive(driveClient, fileName, mimeType, content, parentId)`
-- [ ] `getOrCreateStorage(user, storageType, storageName, githubClient, driveClient)` — **accepts pre-built clients**
-- [ ] `saveScanResults(user, storageInfo, scanResults, url, githubClient, driveClient)` — **accepts pre-built clients**
-- [ ] **No direct calls to `AuthService` methods** — clients passed in from routes
+### Storage Service (`backend/services/storageService.js`) — speaks the contract
+- [ ] **Browse**: `listGitHubRepos(githubClient)` → `{ id(nodeId), full_name, private, html_url }[]`
+      (Google folders come from the client-side Picker, not the backend)
+- [ ] **Fit-check**: `validateStorage(provider, storageRef, clients)` →
+      `{ status, reason?, capabilities, manifestSummary? }` per
+      [accountStorageContract.md → Validation rules](accountStorageContract.md#validation-rules-the-fit-check)
+- [ ] **Load**: `loadAccount(provider, storageRef, clients)` — read manifest +
+      `scans/index.json`, **reconcile drift** by rebuilding from `scans/*.json`
+- [ ] **Init**: `initStorage(provider, storageRef, owner, clients)` — **revalidate**,
+      then conditionally create `equalview.json` + `scans/` skeleton
+- [ ] **Save**: `saveScanResults(account, scanResult, url, clients)` — write immutable
+      `scans/<scanId>_<host>.json`, then update index + manifest summary
+- [ ] GitHub writes pass blob `sha` (optimistic concurrency); prefer a single commit
+- [ ] Drive writes use generation/ETag preconditions; scan file written first
+- [ ] **Accepts pre-built clients** — no direct `AuthService` calls
+- [ ] Scan files immutable; `index.json` + `scanCount` treated as caches
+- [ ] **No** `repos.getForAuthenticatedUser` for existence (use `repos.getContent`/`repos.get`)
+- [ ] **No** `GoogleAuth({ credentials:{access_token} })` (use `OAuth2` + `setCredentials`)
+- [ ] **Never** write tokens/secrets into the store
 
 ### Auth Routes (`backend/routes/auth.js`)
-- [ ] Factory function `makeAuthRouter()` returning Express Router
-- [ ] Apply `authService.middleware()` at router level
-- [ ] `GET /github` — initiate GitHub OAuth (store provider in session)
-- [ ] `GET /google` — initiate Google OAuth (store provider in session)
-- [ ] `GET /github/callback` — handle callback, redirect to `/connect?provider=github`
-- [ ] `GET /google/callback` — handle callback, redirect to `/connect?provider=google`
-- [ ] `POST /storage` — validate body, call `storageService.getOrCreateStorage()` with clients from `authService`, attach `req.user.storage`
-- [ ] `GET /user` — return safe user data (no tokens)
+- [ ] Factory `makeAuthRouter()`; apply `authService.middleware()` at router level
+- [ ] `GET /github`, `GET /google` — initiate OAuth (store provider in session)
+- [ ] `GET /github/callback`, `GET /google/callback` — redirect `/connect?provider=…`
+- [ ] `GET /storages?provider=github` — list repos (GitHub only)
+- [ ] `POST /storage/validate` — fit-check the selected storage
+- [ ] `POST /storage` — `action: "load" | "init"`; **revalidate** then act; attach `req.user.storage`
+- [ ] `GET /user` — safe profile (+ `storage`), **no tokens**
+- [ ] `GET /status` — `{ authenticated, user }`
 - [ ] `POST /logout` — `req.logout()`, destroy session, clear cookie
-- [ ] `GET /status` — return `{ authenticated, user }`
-- [ ] **No import from frontend** (`PROVIDERS` not used here)
-- [ ] Export `module.exports = makeAuthRouter`
+- [ ] **No frontend import** (`PROVIDERS` not used here)
+- [ ] `module.exports = makeAuthRouter`
 
 ### Routes Index (`backend/routes/index.js`)
-- [ ] Import `makeAuthRouter` from `./auth`
+- [ ] `const makeAuthRouter = require('./auth')`
 - [ ] Mount once: `app.use('/api/auth', makeAuthRouter())`
-- [ ] Keep existing scan/problems mounts under `/api` and `/problems`
-- [ ] **No dual mounting** of auth routes
+- [ ] Keep existing `/api` (scan) and `/problems` mounts
+- [ ] **No dual mounting**
 
 ### App.js (`backend/app.js`)
-- [ ] Import `mountRoutes` only (auth routes mounted inside `mountRoutes`)
-- [ ] Pass `storageService` to `ScanController` deps
-- [ ] Import path: `require('./services/storageService')` (not `../services`)
+- [ ] Construct `authService` + `storageService`; pass both to `ScanController` deps
+- [ ] Import path `require('./services/storageService')` (not `../services`)
 
 ### Scan Controller (`backend/controllers/scanController.js`)
-- [ ] Accept `storageService` in constructor deps
-- [ ] In `postScan`: if authenticated and `req.user.storage`, call `storageService.saveScanResults()` with clients from `authService`
+- [ ] Accept `storageService` + `authService` in deps
+- [ ] In `postScan`: if authenticated and `req.user.storage`, build clients and
+      `saveScanResults(...)` — a storage failure logs a warning, **never** fails the scan
 
 ---
 
-## Phase 2: Frontend — Real Auth Integration
+## Phase 2: Frontend — Real Auth + Picker + Fit-check
 
 ### API Client (`frontend/src/lib/apiClient.js`)
-- [ ] Use `credentials: 'include'` on all fetch calls (session cookies)
-- [ ] **Remove** Bearer token logic (no `localStorage` accessToken)
-- [ ] `githubLogin()` → `window.location.href = '/api/auth/github'`
-- [ ] `googleLogin()` → `window.location.href = '/api/auth/google'`
-- [ ] `getAuthStatus()` → `GET /api/auth/status`
-- [ ] `getUser()` → `GET /api/auth/user`
-- [ ] `setupStorage(provider, mode, name)` → `POST /api/auth/storage`
-- [ ] `logout()` → `POST /api/auth/logout`
-- [ ] Keep `runScan`, `getScanResults`, `getProblem` unchanged (already use `/api/...`)
+- [ ] `credentials: 'include'` on all calls; **remove** any Bearer/localStorage token
+- [ ] `githubLogin()` / `googleLogin()` → full redirect to `/api/auth/{provider}`
+- [ ] `getAuthStatus()`, `getUser()`, `logout()`
+- [ ] `listStorages(provider)` → `GET /api/auth/storages?provider=…`
+- [ ] `validateStorage(provider, storageRef)` → `POST /api/auth/storage/validate`
+- [ ] `setupStorage(provider, storageRef, action)` → `POST /api/auth/storage`
+- [ ] Keep `runScan`, `getScanResults`, `getProblem`
+
+### ConnectView (`frontend/src/views/ConnectView.jsx`) — the picker
+- [ ] GitHub: list repos via `listStorages('github')`; Google: launch **Google Picker**
+- [ ] Persistent **"Create new"** option (the `init` path on a fresh store)
+- [ ] On select → `validateStorage` → render fit-check status + scan count
+- [ ] Action button follows status: `loadable`→"Load my account",
+      `initializable`/new→"Set up & continue", `incompatible`/`invalid`→blocked + guidance
+- [ ] Disable init when `capabilities.canWrite === false`
+- [ ] On confirm → `setupStorage(provider, storageRef, action)` → dashboard
+- [ ] Replace hard-coded `existing` lists in `frontend/src/data/placeholders.js`
 
 ### App Routes (`frontend/src/App.jsx`)
-- [ ] State: `user` (from `/api/auth/user`), `provider`, `storageProvider`, `storageName`
-- [ ] On mount: `apiClient.getAuthStatus()` → if authenticated, `apiClient.getUser()` → set user
-- [ ] Listen for `auth:logout` event → clear state, navigate to signin
-- [ ] `auth(provider)` → call `apiClient.githubLogin()` or `googleLogin()` (full redirect)
-- [ ] `connectDone(mode)` → `apiClient.setupStorage(provider, mode, name)` → set storage info → navigate to dashboard
-- [ ] `signOut()` → `apiClient.logout()` → clear state → navigate to landing
-- [ ] **Remove** `setAuthed` / bare `name` references — use `setUser` and `storageName`
+- [ ] State: `user` (from `/api/auth/user`, includes `storage`), `provider`, selection
+- [ ] On mount: `getAuthStatus()` → if authed, `getUser()`
+- [ ] `auth(provider)` → full OAuth redirect
+- [ ] `connectDone()` → `setupStorage(...)` → dashboard
+- [ ] `signOut()` → `logout()` → clear state → landing
+- [ ] Remove `setAuthed` / placeholder-only wiring
 
 ### Views
-- [ ] `SignInView` — accept `providerInfo` prop (optional)
-- [ ] `AccountView` — use `user` prop (real data), not `PLACEHOLDER_USER`
-- [ ] `ConnectView` — accept `storageError` prop for error display
+- [ ] `AccountView` — real `user` + `storage` (not `PLACEHOLDER_USER`); "saved scans" from index
+- [ ] `DashboardView` — saved scans from the loaded index (not `PLACEHOLDER_SAVED_SCANS`)
+- [ ] `ConnectView` — accept a `storageError` prop for failures
 
 ---
 
 ## Phase 3: Testing & Documentation
 
 ### Tests
-- [ ] `backend/tests/auth.test.js` — test OAuth redirects, callbacks
-- [ ] `backend/tests/storage.test.js` — test storage creation (mock authenticated user)
-- [ ] `frontend/tests/apiClient.test.js` — test auth methods
+- [ ] `backend/tests/auth.test.js` — OAuth redirects, callbacks, status/logout
+- [ ] `backend/tests/storage.test.js` — fit-check matrix (loadable / initializable /
+      unrelated / incompatible / invalid), load-time reconcile, init race guard,
+      atomic save (mock authenticated user + mock clients)
+- [ ] `frontend/tests/apiClient.test.js` — auth + storage methods
+- [ ] `frontend/tests/connectView.test.jsx` — picker + fit-check rendering per status
 
 ### Documentation
-- [ ] Update `backend/README.md` with:
-  - [ ] Auth endpoints table
-  - [ ] Environment setup instructions
-  - [ ] OAuth app configuration steps
-  - [ ] Required scopes
-  - [ ] Testing instructions
-- [ ] Verify acceptance criteria match design doc (no "no frontend changes" claim)
+- [ ] `backend/README.md`: auth/storage endpoints table, env setup, OAuth/Picker
+      config, scopes, testing
+- [ ] Keep this TODO and the design/contract docs in sync if implementation diverges
 
 ---
 
-## Verification Checklist (Run Before Marking Complete)
+## Verification checklist (run before marking complete)
 
-- [ ] `grep -r "makeAuthRouter" backend/routes/` — factory used, not instance
-- [ ] `grep -r "mountAuthRoutes" backend/` — **zero matches** (no dual mount)
-- [ ] `grep -r "/auth/github" frontend/src/lib/apiClient.js` — paths include `/api/auth/`
-- [ ] `grep -r "credentials: 'include'" frontend/src/lib/apiClient.js` — present on fetch
-- [ ] `grep -r "getGitHubClient" backend/services/storageService.js` — **zero matches** (clients passed in)
-- [ ] `grep -r "PROVIDERS" backend/routes/auth.js` — **zero matches** (no frontend import)
-- [ ] `grep -r "repos.getForAuthenticatedUser" backend/` — **zero matches** (use `repos.get({owner, repo})`)
-- [ ] `grep -r "GoogleAuth.*credentials.*access_token" backend/` — **zero matches** (use OAuth2 + setCredentials)
-- [ ] `grep -r "../services/storageService" backend/app.js` — **zero matches** (use `./services/storageService`)
-- [ ] `grep -r "deserializeUser" backend/services/authService.js` — has `// TODO: load full user from DB`
-- [ ] `grep -r "setAuthed" frontend/src/App.jsx` — **zero matches** (use `setUser`)
+- [ ] `grep -r "makeAuthRouter" backend/routes/` — factory used, mounted once
+- [ ] `grep -r "mountAuthRoutes" backend/` — **zero** (no dual mount)
+- [ ] `grep -r "credentials: 'include'" frontend/src/lib/apiClient.js` — present
+- [ ] `grep -rn "validateStorage\|listStorages\|setupStorage" frontend/src/lib/apiClient.js` — all present
+- [ ] `grep -r "getForAuthenticatedUser" backend/` — **zero** (use `repos.get`/`getContent`)
+- [ ] `grep -r "credentials.*access_token" backend/` — **zero** (use `setCredentials`)
+- [ ] `grep -r "PROVIDERS" backend/routes/auth.js` — **zero** (no frontend import)
+- [ ] `grep -rn "drive.file\|drive.metadata.readonly" backend/` — scope matches the locked decision
+- [ ] `grep -rn "sha" backend/services/storageService.js` — GitHub writes pass a blob sha
+- [ ] No tokens written to the store: review `initStorage` / `saveScanResults` payloads
 
 ---
 
 ## Notes
 
-- Each checkbox represents a verifiable claim. If you can't verify it in the actual code, it's not done.
-- Prefer small, testable PRs over one big merge.
-- Design doc (`githubGoogleAuthStorageImplementation.md`) is the source of truth — update it if implementation diverges.
+- Each checkbox is a verifiable claim. If you can't verify it in real code, it's not done.
+- Prefer small, testable PRs.
+- [`githubGoogleAuthStorageImplementation.md`](githubGoogleAuthStorageImplementation.md)
+  (flow/API) and [`accountStorageContract.md`](accountStorageContract.md) (bytes)
+  are the source of truth — update them if the implementation diverges.

--- a/docs/guides/auth_storage_guide/accountStorageContract.md
+++ b/docs/guides/auth_storage_guide/accountStorageContract.md
@@ -1,0 +1,216 @@
+# Account Storage Contract — "the data needed to load back the account"
+
+This file is the **source of truth** for what a valid EqualView account store
+looks like inside a user's GitHub repository or Google Drive folder. The
+fit-check (`POST /api/auth/storage/validate`) reads this; load/init write it.
+The auth + flow design lives in
+[`githubGoogleAuthStorageImplementation.md`](githubGoogleAuthStorageImplementation.md).
+
+The whole point: an account is **portable**. Anything required to reconstruct a
+user's EqualView account on a fresh device must live *in the store*, described
+here — nothing essential lives on an EqualView server.
+
+---
+
+## On-disk layout
+
+The store is rooted at the repo root (GitHub) or the selected folder (Drive):
+
+```
+<storage root>/
+├── equalview.json          # manifest — identity + storage binding + cached summary
+└── scans/
+    ├── index.json          # cache: lightweight list for the dashboard
+    ├── 9f3c…a1_codrlabs.com.json     # one immutable scan, named <scanId>_<host>.json
+    └── 2b7e…04_stripe.com.json
+```
+
+**Truth vs. cache.** The immutable files in `scans/` are the truth. `index.json`
+and `equalview.json → summary.scanCount` are **caches** — always rebuildable by
+listing `scans/*.json`. Readers reconcile on load; they never trust a cache over
+the files.
+
+---
+
+## Manifest — `equalview.json`
+
+```jsonc
+{
+  "equalview": true,                 // presence + true ⇒ this is an EV store
+  "kind": "account-store",
+  "schemaVersion": 1,                // bump on breaking layout changes
+  "minReaderSchemaVersion": 1,       // oldest reader that may safely OPEN this
+
+  "account": {
+    "id": "uuid-v4",                 // random, stable; NOT email/login
+    "createdAt": "2026-06-30T18:04:00Z",
+    "updatedAt": "2026-06-30T18:04:00Z"
+  },
+
+  "storage": {
+    "provider": "github",            // "github" | "google"
+    "providerStorageId": "R_kgDOA…", // repo node id / Drive folder id — stable
+    "ownerId": "MDQ6VXNlcj…",        // stable provider user/org id (display/binding)
+    "ownerDisplay": "samuel",        // login or email — debug/display only
+    "repo": "samuel/site-audits",    // GitHub only; display/debug
+    "branch": "main"                 // GitHub only
+  },
+
+  "settings": {
+    "autoDelete90d": true
+  },
+
+  "summary": {                       // CACHE — rebuildable from scans/
+    "scanCount": 12,
+    "lastScanAt": "2026-06-30T18:03:10Z"
+  },
+
+  "features": []                     // forward-compat capability flags
+}
+```
+
+### Field rules
+
+- `account.id` is a **random UUID** minted at init and never changed. It is the
+  account identity; the provider login/email are display only.
+- `storage.providerStorageId` / `storage.ownerId` are **stable provider ids**
+  (repo node id, Drive folder id, user/org id). Names change; ids don't.
+- `schemaVersion` is for **breaking** changes; `minReaderSchemaVersion` lets a
+  newer writer mark a store unreadable by too-old clients.
+- `summary` and `scanCount` are caches. Never block a load because they disagree
+  with `scans/` — reconcile instead.
+- **Never** store OAuth tokens, refresh tokens, API keys, or any secret here.
+
+---
+
+## Scan index — `scans/index.json`
+
+A cache to render the dashboard without downloading every scan.
+
+```jsonc
+{
+  "schemaVersion": 1,
+  "scans": [
+    {
+      "id": "9f3c…a1",               // UUID; matches the scan filename prefix
+      "url": "https://codrlabs.com",
+      "host": "codrlabs.com",
+      "scannedAt": "2026-06-30T18:03:10Z",
+      "score": 72,
+      "issues": 7,
+      "topSeverity": "critical",
+      "file": "scans/9f3c…a1_codrlabs.com.json",
+      "size": 18342,                 // bytes — helps drift/corruption checks
+      "sha256": "…"                  // optional integrity check
+    }
+  ]
+}
+```
+
+- Entries are keyed by **UUID**, not `host_timestamp` (collisions, re-scans).
+- `size`/`sha256` let load-time reconcile detect corruption cheaply.
+
+---
+
+## Scan file — `scans/<scanId>_<host>.json`
+
+Immutable. The full `ScanResult` (see
+[`../../../shared/types.js`](../../../shared/types.js)) plus a small wrapper:
+
+```jsonc
+{
+  "id": "9f3c…a1",
+  "schemaVersion": 1,
+  "url": "https://codrlabs.com",
+  "scannedAt": "2026-06-30T18:03:10Z",
+  "result": { /* ScanResult: problems, whatsGood, … */ }
+}
+```
+
+Never rewritten in place. "Delete" removes the file and the index entry (GitHub
+history still retains it — disclose this).
+
+---
+
+## Validation rules (the fit-check)
+
+Given a selected storage, the backend decides a `status` (+ optional `reason` +
+`capabilities`). This is exactly what ConnectView renders.
+
+```
+read <root>/equalview.json
+ ├─ not found
+ │   ├─ store empty (no other files)            → initializable
+ │   └─ store has unrelated files               → unrelated
+ ├─ found but unparseable / missing required    → invalid (reason: malformed_manifest)
+ ├─ found, duplicate manifest (Drive)           → invalid (reason: duplicate_manifest)
+ ├─ found, equalview !== true                   → unrelated
+ ├─ found, schemaVersion > server supports       → incompatible (reason: too_new)
+ ├─ found, schemaVersion < server, migratable   → loadable (reason: migration_required)
+ └─ found, supported schemaVersion              → loadable
+                                                   (reason: repairable if index drift)
+```
+
+Always attach capabilities probed against the provider:
+
+```ts
+capabilities: { canRead: boolean; canWrite: boolean; canCreate: boolean }
+```
+
+Example: a read-only fork → `loadable` with `canWrite:false` (UI allows browsing
+saved scans but disables new saves and init).
+
+### Load-time reconciliation
+
+On `action: "load"`:
+
+1. List `scans/*.json`.
+2. Rebuild the index from the files; drop entries with no file (orphans) and
+   files that fail to parse (corrupt).
+3. If the rebuilt index differs from `index.json`, rewrite it and set
+   `summary.scanCount` / `lastScanAt`. Surface `reason: "repairable"` to the UI.
+
+### Init-time race guard
+
+On `action: "init"`, **revalidate** immediately before writing. Only create
+`equalview.json` if it still does not exist (conditional create). Never trust a
+stale `validate` result — another device may have initialized in between.
+
+---
+
+## Write atomicity
+
+All multi-file account mutations (new scan = scan file + index + manifest
+summary) must be atomic or partial-write tolerant:
+
+- **GitHub**: prefer a **single commit** carrying all changed files; write
+  against the expected branch HEAD / blob `sha` (optimistic concurrency). On a
+  `409`/stale-sha, refetch and retry.
+- **Google Drive**: no multi-file transaction — write the **immutable scan file
+  first** (so truth is never lost), then update `index.json` and the manifest
+  using ETag/generation preconditions; rely on load-time reconcile to heal any
+  gap.
+
+---
+
+## Versioning & migration
+
+- **Patch/additive** changes (new optional field, new `features` flag): no
+  `schemaVersion` bump; old readers ignore unknown fields.
+- **Breaking** changes (renamed/removed fields, layout move): bump
+  `schemaVersion`; set `minReaderSchemaVersion` so older clients report
+  `incompatible` instead of corrupting the store.
+- **Migration** (`reason: "migration_required"`): back up or be retry-safe,
+  transform, then bump `schemaVersion` — only on a writable store.
+
+---
+
+## Quick checklist for implementers
+
+- [ ] `equalview.json` written with random `account.id` + stable provider ids.
+- [ ] Scan files immutable, named `<scanId>_<host>.json`, scanId is a UUID.
+- [ ] `index.json` + `summary` treated as caches; rebuilt on load.
+- [ ] Fit-check returns `status` + `reason` + `capabilities`.
+- [ ] `init` revalidates and conditionally creates the manifest.
+- [ ] GitHub writes use blob `sha`; Drive writes use generation/ETag.
+- [ ] No tokens/secrets ever written into the store.

--- a/docs/guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md
+++ b/docs/guides/auth_storage_guide/githubGoogleAuthStorageImplementation.md
@@ -1,10 +1,36 @@
-# GitHub/Google Authentication and Storage Integration — Design Doc
+# GitHub/Google Authentication and Portable-Storage Integration — Design Doc
 
 ## Overview
 
-This document describes the design for implementing complete GitHub and Google authentication flows along with storage integration for saving scan results to either GitHub repositories or Google Drive folders.
+EqualView lets a person sign in with **GitHub** or **Google** and keep their
+whole account — profile, settings, and saved accessibility scans — inside
+**storage they already own**: one **GitHub repository** or one **Google Drive
+folder**. EqualView runs **no database of its own**. The user-owned storage is
+the source of truth; OAuth is used only to *identify* the user and obtain an API
+token to read/write that storage.
 
-**Status**: Design phase — implementation tracked in `TODO.md`
+This is a **bring-your-own-storage, portable account** model. Because the
+account travels with the user's repo/folder, they can sign in from any device,
+**pick the same storage**, and EqualView **loads the account back** — no
+server-side data, no lock-in, no per-user hosting cost. That is what makes it
+cheap to offer to as many people as possible.
+
+The defining UX is **browse → select → validate → load-or-init**:
+
+1. The user connects GitHub or Google (OAuth).
+2. They **see the repos/folders they already have** and **select one**.
+3. EqualView **validates** whether that storage *fits the data needed to load
+   the account back* (a "fit-check").
+4. Depending on the result, EqualView **loads** the existing account or
+   **initializes** the storage as a new EqualView account store.
+
+> The exact on-disk contract that the fit-check reads/writes — the manifest,
+> the scans layout, and the validation rules — lives in its own document:
+> [`accountStorageContract.md`](accountStorageContract.md). **That file is the
+> source of truth for "the data needed to load back the account."** This doc
+> covers the auth + flow + API design; that doc covers the bytes.
+
+**Status**: Design phase — implementation tracked in [`TODO.md`](TODO.md).
 
 ---
 
@@ -13,10 +39,10 @@ This document describes the design for implementing complete GitHub and Google a
 ### High-Level Flow
 
 ```
-User clicks "Sign in with GitHub/Google"
+User clicks "Sign in with GitHub / Google"
          │
          ▼
-Backend initiates OAuth flow (passport-github2 / passport-google-oauth20)
+Backend initiates OAuth (passport-github2 / passport-google-oauth20)
          │
          ▼
 Provider redirects to /api/auth/{provider}/callback with auth code
@@ -25,27 +51,124 @@ Provider redirects to /api/auth/{provider}/callback with auth code
 Backend exchanges code for tokens → encrypts tokens → stores in session
          │
          ▼
-User redirected to ConnectView for storage selection
+User lands on ConnectView — the storage picker
+         │
+         ├─ GitHub: backend lists the user's repos      → user selects one
+         └─ Google: Google Picker lists Drive folders    → user selects one
          │
          ▼
-User selects provider (github/google) + mode (new/existing) + name
+Backend VALIDATES the selected storage (fit-check)
+  reads <root>/equalview.json → returns a status + capabilities
          │
-         ▼
-Backend creates/retrieves storage (GitHub repo or Google Drive folder)
-         │
-         ▼
-Storage info attached to user session → User redirected to Dashboard
-         │
-         ▼
-On scan: if authenticated, results saved to user's configured storage
+   ┌─────┴───────────────────────────────────────────────┐
+   ▼                 ▼                 ▼                   ▼
+loadable        initializable      incompatible        unrelated / invalid
+   │                 │                 │                   │
+   ▼                 ▼                 ▼                   ▼
+"Load my       "Set this up      "Made by a newer    "This isn't an EV
+ account"       for EqualView"     EqualView —          store / it has other
+   │                 │              update to use it"    files — init anyway
+   ▼                 ▼                 │                   or pick another"
+LOAD: read       INIT: write          ▼                   │
+manifest +       manifest +        (blocked)              ▼
+scans/index      scans/ dir                            (init or cancel)
+   └─────────────────┴───────────────────────────────────┘
+                     │
+                     ▼
+        Account attached to session → Dashboard
+                     │
+                     ▼
+   On scan: results appended to the user's storage (atomic write)
 ```
+
+The user can also choose **"Create a new repo/folder"** instead of selecting an
+existing one — that is just the `initializable` path against a freshly created
+store.
+
+### Identity model — read this first
+
+This model is **possession-based by default**: whoever can read/write the
+selected repo/folder can load and modify that EqualView account. This is a
+deliberate tradeoff for portability and zero-server-state, but it has sharp
+edges the implementation must respect:
+
+- A **collaborator** on a shared GitHub repo, or a member of a shared Drive
+  folder, can load/modify the account. Treat the storage ACL as the account ACL.
+- The manifest records a **stable provider owner id** (`storage.ownerId`) for
+  *display and optional binding*, never the email/login as the only identity.
+- If you later want **subject-bound** accounts (reject load when the OAuth
+  subject ≠ `storage.ownerId`), it is a one-field policy change — but it hurts
+  copy/share/recovery, so it is opt-in, not the default.
 
 ### Security Model
 
-- **Session-based auth**: Uses `express-session` with secure cookies (`credentials: 'include'`)
-- **Token encryption**: All OAuth tokens encrypted at rest using AES-256-GCM
-- **Token refresh**: Google refresh tokens supported; GitHub tokens are long-lived
-- **Scope minimization**: Only request required scopes (`repo`, `user:email` for GitHub; `drive.file`, `profile`, `email` for Google)
+- **Session-based auth**: `express-session` with secure, httpOnly cookies;
+  the frontend uses `credentials: 'include'` and never sees a token.
+- **Token handling**: OAuth access/refresh tokens are encrypted at rest
+  (AES-256-GCM via `ENCRYPTION_KEY`) and held in the session store. **Tokens are
+  never written into the user's repo/folder.**
+- **Token refresh**: Google access tokens are refreshed via the refresh token;
+  GitHub OAuth tokens are long-lived.
+- **Scope minimization vs. "browse existing storage"**: listing storage the
+  user *already has* fundamentally needs broader read than `drive.file` /
+  app-only access grants. See [Scopes & Browsing Reality](#scopes--browsing-reality)
+  — this is the single most important constraint in the whole design.
+- **Privacy of the storage itself**:
+  - A **public** GitHub repo makes scans + settings public.
+  - A **private** repo is still visible to repo collaborators, and Git history
+    retains deleted scans unless history is rewritten.
+  - A **shared** Drive folder exposes data to folder collaborators.
+  - Surface these facts in the picker so the user chooses knowingly.
+
+---
+
+## Scopes & Browsing Reality
+
+> The naive "list every folder/repo the user owns" requires more access than the
+> minimal write scope. The design must be explicit about the tradeoff per
+> provider, and the picker must explain it to the user.
+
+### Google Drive — `drive.file` cannot browse existing folders
+
+`drive.file` only grants access to files/folders the **app created** or the user
+**explicitly opened/shared** with the app. It **cannot** list the folders a user
+already has. Two valid strategies:
+
+1. **Google Picker (recommended, privacy-preserving).**
+   - Scopes: `openid email profile` + `https://www.googleapis.com/auth/drive.file`.
+   - The user browses in Google's own Picker UI and hands EqualView exactly the
+     one folder they chose (or a new one). EqualView gets access to *only* that
+     folder.
+   - Consequence: for Google, the picker is **client-side (Google Picker)**, not
+     a backend `GET /api/auth/storages` listing. The selected folder id is then
+     POSTed to validate/attach.
+
+2. **App-rendered browse (heavier).**
+   - Scopes: `https://www.googleapis.com/auth/drive.metadata.readonly` (to list
+     folder metadata) + `drive.file` (to write the chosen store).
+   - Tradeoff: EqualView can read metadata for *all* of the user's Drive, which
+     is a real privacy cost to disclose.
+
+   **Avoid** the full `https://www.googleapis.com/auth/drive` scope — broad
+   read/write/delete over all of Drive, plus a heavier Google verification
+   burden.
+
+### GitHub — OAuth scope is all-or-nothing
+
+Classic GitHub **OAuth Apps** have coarse scopes:
+
+| Need | Scope | Tradeoff |
+| --- | --- | --- |
+| List/read/write **public** repos only | `public_repo` | No private repos |
+| List/read/write **private** repos | `repo` | Grants read/write to **all** repos the user can access |
+| Identity | `read:user` (+ `user:email` only if a verified email is required) | — |
+
+There is **no per-repo or read-only-source scope** for classic OAuth Apps.
+
+**Recommended for least privilege:** ship a **GitHub App** instead, where the
+user installs EqualView on selected repositories with `Contents: read/write` +
+`Metadata: read`. The UX becomes GitHub's install/repo-select flow rather than
+"list all repos from a token." Document both; pick one before implementation.
 
 ---
 
@@ -53,59 +176,86 @@ On scan: if authenticated, results saved to user's configured storage
 
 ### 1. Auth Service (`backend/services/authService.js`)
 
-**Responsibilities:**
-- Configure Passport strategies (GitHub, Google)
-- Encrypt/decrypt OAuth tokens
-- Provide authenticated API clients (Octokit, Google Drive)
-- Handle token refresh (Google)
+**Responsibilities**
+- Configure Passport strategies (GitHub, Google) and the session middleware.
+- Encrypt/decrypt OAuth tokens (AES-256-GCM).
+- Build authenticated API clients on demand and hand them to the storage service.
+- Refresh Google access tokens.
 
-**Key Methods:**
-- `middleware()` — returns `[session(), passport.initialize(), passport.session()]`
-- `getGitHubClient(user)` — returns authenticated Octokit instance
-- `getGoogleDriveClient(user)` — returns authenticated Google Drive client
-- `refreshGoogleToken(user)` — refreshes expired Google access token
+**Key methods**
+- `middleware()` → `[session(), passport.initialize(), passport.session()]`
+- `getGitHubClient(user)` → authenticated Octokit
+- `getGoogleDriveClient(user)` → authenticated Google Drive client (OAuth2 +
+  `setCredentials({ access_token })`)
+- `refreshGoogleToken(user)` → refreshes an expired Google access token
 
-**Note**: `deserializeUser` is a stub returning `{ id }`. In production, this should fetch the full user (including encrypted tokens) from a database.
-
----
+> `deserializeUser` is a **stub** returning `{ id, ...session fields }`. There is
+> no user DB; the "user" is the session payload (identity + encrypted tokens +
+> attached `storage`). `// TODO: load full user from DB` only applies if a future
+> phase adds server-side persistence.
 
 ### 2. Storage Service (`backend/services/storageService.js`)
 
-**Responsibilities:**
-- GitHub: create repos, create/update files
-- Google Drive: create folders, upload files
-- Get-or-create storage for a user
-- Save scan results to configured storage
+The storage service is where the **portable-account contract** is read and
+written. It speaks the layout in
+[`accountStorageContract.md`](accountStorageContract.md). It receives
+**pre-built authenticated clients** as arguments (no direct `AuthService` calls →
+no circular dependency).
 
-**Key Methods:**
-- `createGitHubRepo(githubClient, repoName, private)`
-- `createGitHubFile(githubClient, owner, repo, path, content, branch)`
-- `createGoogleDriveFolder(driveClient, folderName, parentId)`
-- `uploadToGoogleDrive(driveClient, fileName, mimeType, content, parentId)`
-- `getOrCreateStorage(user, storageType, storageName)` — **accepts pre-built clients**
-- `saveScanResults(user, storageInfo, scanResults, url)`
+**Browsing**
+- `listGitHubRepos(githubClient)` → repos the user can write, each with stable
+  `id` (node id), `full_name`, `private`, `html_url`.
+- *(Google folders are chosen client-side via Google Picker; the backend does
+  not list them when using `drive.file`.)*
 
-**Design Decision**: `getOrCreateStorage` and `saveScanResults` receive authenticated clients as arguments (built by `AuthService`) rather than calling `AuthService` methods directly. This avoids circular dependencies and keeps services decoupled.
+**Fit-check (the core of the UX)**
+- `validateStorage(provider, storageRef, githubClient, driveClient)` →
+  `{ status, reason?, capabilities, manifestSummary? }`. Reads
+  `<root>/equalview.json`, checks `schemaVersion`, cross-checks `scans/index.json`
+  vs. actual files, and probes write capability. See
+  [Fit-check status](#fit-check-status) for the enum.
 
----
+**Load / initialize**
+- `loadAccount(provider, storageRef, clients)` → reads manifest + `scans/index.json`,
+  reconciles drift, returns the rehydrated account (settings + scan index).
+- `initStorage(provider, storageRef, owner, clients)` → **revalidates**, then
+  atomically writes `equalview.json` + `scans/` skeleton. Returns the new account.
+
+**Saving scans**
+- `saveScanResults(account, scanResult, url, clients)` → writes one immutable
+  `scans/<host>_<ts>.json`, then updates `scans/index.json` + manifest `summary`
+  **in a single atomic commit** (GitHub) or with generation/ETag preconditions
+  (Drive). Scan files are the truth; `index.json`/`scanCount` are caches.
+
+**Design rules baked in**
+- Scan files are **immutable** and the index is **rebuildable** from them.
+- Every multi-file update is **atomic or revalidated** to survive partial writes.
+- `getOrCreateStorage` / `saveScanResults` **accept pre-built clients**.
+- **No `repos.getForAuthenticatedUser`** for existence checks — use
+  `repos.get({ owner, repo })`. **No** `GoogleAuth({ credentials: { access_token }})`
+  — use `OAuth2 + setCredentials`.
 
 ### 3. Auth Routes (`backend/routes/auth.js`)
 
-**Convention**: Factory function `makeAuthRouter()` returning an Express Router (matching `makeScanRouter`, `makeProblemsRouter`).
+Factory `makeAuthRouter()` returning an Express Router (matching
+`makeScanRouter` / `makeProblemsRouter`). `authService.middleware()` is applied
+at router level. **No frontend imports** (`PROVIDERS` lives in the frontend only).
 
-**Endpoints:**
 | Method | Path | Description |
-|--------|------|-------------|
+| --- | --- | --- |
 | GET | `/api/auth/github` | Initiate GitHub OAuth |
 | GET | `/api/auth/google` | Initiate Google OAuth |
-| GET | `/api/auth/github/callback` | GitHub OAuth callback |
-| GET | `/api/auth/google/callback` | Google OAuth callback |
-| POST | `/api/auth/storage` | Configure user's storage |
-| GET | `/api/auth/user` | Get current user profile |
-| POST | `/api/auth/logout` | Logout and destroy session |
-| GET | `/api/auth/status` | Check auth status |
+| GET | `/api/auth/github/callback` | GitHub callback → redirect `/connect?provider=github` |
+| GET | `/api/auth/google/callback` | Google callback → redirect `/connect?provider=google` |
+| GET | `/api/auth/storages?provider=github` | List the user's repos (GitHub only; Google uses Picker) |
+| POST | `/api/auth/storage/validate` | **Fit-check** a selected storage |
+| POST | `/api/auth/storage` | `action: "load" \| "init"` → rehydrate or initialize, attach to session |
+| GET | `/api/auth/user` | Current user profile (+ `storage` if attached). No tokens. |
+| GET | `/api/auth/status` | `{ authenticated, user }` |
+| POST | `/api/auth/logout` | `req.logout()`, destroy session, clear cookie |
 
-**Mounting**: In `backend/routes/index.js`:
+**Mounting** — exactly once, in `backend/routes/index.js`:
+
 ```js
 const makeAuthRouter = require('./auth');
 function mountRoutes(app, { scanController }) {
@@ -115,101 +265,191 @@ function mountRoutes(app, { scanController }) {
 }
 ```
 
-**No dual mounting** — auth routes registered exactly once via the factory.
-
----
+No dual mounting.
 
 ### 4. Scan Controller Integration
 
-`ScanController` receives `storageService` as a dependency. In `postScan`:
+`ScanController` receives `storageService` (and, to build clients,
+`authService`) as deps. In `postScan`, after a successful scan:
+
 ```js
-if (req.isAuthenticated() && req.user && req.user.storage) {
-  await storageService.saveScanResults(req.user, req.user.storage, result, url);
+if (req.isAuthenticated() && req.user?.storage) {
+  const clients = await authService.clientsFor(req.user);
+  await storageService.saveScanResults(req.user, result, url, clients);
 }
 ```
+
+Saving must **never** break the scan response — a storage failure is logged and
+surfaced as a non-fatal warning, not a 500 on the scan itself.
+
+---
+
+## Fit-check status
+
+`POST /api/auth/storage/validate` returns a `status` + optional `reason` +
+`capabilities`. The status drives the ConnectView copy and which action button
+is offered.
+
+| status | meaning | UI offers |
+| --- | --- | --- |
+| `loadable` | Valid `equalview.json`, supported `schemaVersion` | **Load my account** (shows scan count) |
+| `initializable` | Storage is empty / has no EqualView files | **Set up for EqualView** |
+| `unrelated` | Non-empty, no manifest, has other files | Init anyway / pick another (warn) |
+| `incompatible` | `schemaVersion` newer than this server supports | Blocked — update EqualView |
+| `invalid` | Manifest present but malformed / missing fields / duplicate manifest | Blocked — pick another or repair |
+
+Optional refinements (model as `reason`, not new top-level states, to keep the
+client simple):
+
+- `reason: "migration_required"` (older supported schema → migrate before write)
+- `reason: "repairable"` (manifest OK but `index.json` drifted → rebuild on load)
+- `reason: "duplicate_manifest"` (Drive can hold two `equalview.json` → ambiguous)
+- `reason: "access_denied" | "not_writable" | "not_found" | "temporarily_unavailable"`
+
+Every result also carries:
+
+```ts
+capabilities: { canRead: boolean; canWrite: boolean; canCreate: boolean }
+```
+
+so the UI can, e.g., allow **load** but disable **init** on a read-only fork.
+
+---
+
+## Concurrency, partial writes & drift
+
+Because the store is a plain repo/folder the user (and their collaborators, and
+other devices) can touch, the design **must** assume concurrent and partial
+writes:
+
+- **Optimistic concurrency.**
+  - GitHub: write against the expected branch HEAD / blob SHA; prefer **one
+    atomic commit** containing the new scan file + updated index + updated
+    manifest.
+  - Drive: use ETag/generation preconditions where available; expect retries.
+- **Partial-write tolerance.** A scan file may land without the index updating
+  (or vice versa). Therefore: scan files are immutable truth; `index.json` and
+  `manifest.summary.scanCount` are **caches**, reconciled on load.
+- **Drift repair.** On load, if the index disagrees with the actual
+  `scans/*.json`, rebuild the index from disk, drop orphan/corrupt entries, and
+  surface `reason: "repairable"`.
+- **Validate→init race.** A `validate` result can go stale before `init`.
+  `POST /api/auth/storage { action: "init" }` must **revalidate and
+  conditionally create** `equalview.json`; never trust a stale validate result.
+- **Object identity.** Persist the **repo node id / Drive folder id**, not the
+  name — repos get renamed/transferred and Drive folder names are not unique.
 
 ---
 
 ## Frontend Design
 
-### 1. API Client (`frontend/src/lib/apiClient.js`)
+### API Client (`frontend/src/lib/apiClient.js`)
 
-**Auth Model**: Session cookies (not Bearer tokens). The frontend:
-- Calls `/api/auth/...` endpoints with `credentials: 'include'`
-- Does **not** store access tokens in localStorage
-- Relies on browser automatically sending session cookie
+Session cookies, not Bearer tokens. All calls use `credentials: 'include'`; no
+`localStorage` token.
 
-**Endpoints match backend routes** (all prefixed with `/api/auth/`):
 - `githubLogin()` → `window.location.href = '/api/auth/github'`
 - `googleLogin()` → `window.location.href = '/api/auth/google'`
 - `getAuthStatus()` → `GET /api/auth/status`
 - `getUser()` → `GET /api/auth/user`
-- `setupStorage(provider, mode, name)` → `POST /api/auth/storage`
+- `listStorages(provider)` → `GET /api/auth/storages?provider=…` (GitHub)
+- `validateStorage(provider, storageRef)` → `POST /api/auth/storage/validate`
+- `setupStorage(provider, storageRef, action)` → `POST /api/auth/storage`
 - `logout()` → `POST /api/auth/logout`
+- `runScan`, `getScanResults`, `getProblem` unchanged.
 
----
+For Google, selection is done with the **Google Picker** client library; the
+chosen folder id flows into `validateStorage` / `setupStorage`.
 
-### 2. App Routes (`frontend/src/App.jsx`)
+### ConnectView — the picker (`frontend/src/views/ConnectView.jsx`)
 
-**State**: `user` object from `/api/auth/user` (includes `storage` when configured).
+Today this is a placeholder with hard-coded `existing` lists in
+`frontend/src/data/placeholders.js`. The real ConnectView:
 
-**Flow:**
-1. On load: `apiClient.getAuthStatus()` → if authenticated, `apiClient.getUser()` → set user
-2. Sign in: redirect to `/api/auth/{provider}` (full page redirect for OAuth)
-3. Callback: backend redirects to `/connect?provider={provider}`
-4. Connect: user selects storage → `apiClient.setupStorage()` → redirect to dashboard
-5. Scan: `apiClient.runScan()` automatically includes session cookie
+1. **Lists real storage.** GitHub → `listStorages('github')`. Google → launch
+   Google Picker. Plus a persistent **"Create new"** option.
+2. **Validates on select.** On pick, call `validateStorage` and render the
+   fit-check result (status copy + scan count when `loadable`).
+3. **Offers the right action.** Button text follows status:
+   `loadable` → "Load my account", `initializable`/new → "Set up & continue",
+   `incompatible`/`invalid` → blocked with guidance.
+4. **Confirms.** `setupStorage(provider, storageRef, action)` → on success the
+   account (with `storage`) is attached; navigate to the dashboard.
+
+### App routes (`frontend/src/App.jsx`)
+
+State: `user` (from `/api/auth/user`, includes `storage` once attached),
+`provider`, and storage selection. On mount: `getAuthStatus()` → if
+authenticated, `getUser()`. `auth(provider)` does a full OAuth redirect.
+`connectDone()` calls `setupStorage` then navigates to the dashboard.
+`signOut()` calls `logout()` and clears state. Remove the `setAuthed` /
+placeholder-only wiring.
 
 ---
 
 ## API Contracts
 
-### POST `/api/auth/storage`
-**Request:**
+### `GET /api/auth/storages?provider=github`
 ```json
 {
-  "provider": "github" | "google",
-  "mode": "new" | "existing",
-  "name": "repository-or-folder-name"
+  "provider": "github",
+  "storages": [
+    { "id": "R_kgDOA…", "name": "site-audits", "full_name": "sam/site-audits",
+      "private": true, "html_url": "https://github.com/sam/site-audits" }
+  ]
 }
 ```
-**Response (200):**
+*(Google omitted — folders are selected via Google Picker, which returns the
+folder id directly to the client.)*
+
+### `POST /api/auth/storage/validate`
+**Request**
+```json
+{ "provider": "github", "storageRef": { "id": "R_kgDOA…", "full_name": "sam/site-audits" } }
+```
+**Response (200)**
+```json
+{
+  "status": "loadable",
+  "reason": null,
+  "capabilities": { "canRead": true, "canWrite": true, "canCreate": false },
+  "manifestSummary": { "accountId": "…", "schemaVersion": 1, "scanCount": 12, "updatedAt": "…" }
+}
+```
+
+### `POST /api/auth/storage`
+**Request**
+```json
+{ "provider": "github",
+  "storageRef": { "id": "R_kgDOA…", "full_name": "sam/site-audits" },
+  "action": "load" }
+```
+`action` is `"load"` (rehydrate an existing store) or `"init"` (write a fresh
+manifest + `scans/`). The server **revalidates** before acting.
+
+**Response (200)**
 ```json
 {
   "success": true,
   "provider": "github",
-  "storage": {
-    "type": "github",
-    "id": "123",
-    "name": "my-repo",
-    "full_name": "user/my-repo",
-    "html_url": "https://github.com/user/my-repo",
-    "clone_url": "https://github.com/user/my-repo.git"
-  }
+  "storage": { "type": "github", "id": "R_kgDOA…", "full_name": "sam/site-audits",
+               "html_url": "https://github.com/sam/site-audits" },
+  "account": { "accountId": "…", "settings": { "autoDelete90d": true }, "scanCount": 12 }
 }
 ```
 
-### GET `/api/auth/user`
-**Response (200):**
+### `GET /api/auth/user`
 ```json
 {
-  "id": "12345",
-  "username": "samuel",
-  "email": "sam@example.com",
-  "displayName": "Samuel",
-  "provider": "github",
-  "avatarUrl": "https://...",
-  "storage": { /* storage info if configured */ }
+  "id": "12345", "username": "samuel", "email": "sam@example.com",
+  "displayName": "Samuel", "provider": "github", "avatarUrl": "https://…",
+  "storage": { "type": "github", "full_name": "sam/site-audits" }
 }
 ```
 
-### GET `/api/auth/status`
-**Response (200):**
+### `GET /api/auth/status`
 ```json
-{
-  "authenticated": true,
-  "user": { "id": "12345", "username": "samuel", ... }
-}
+{ "authenticated": true, "user": { "id": "12345", "username": "samuel" } }
 ```
 
 ---
@@ -217,17 +457,21 @@ if (req.isAuthenticated() && req.user && req.user.storage) {
 ## Environment Variables
 
 ```env
-# Authentication
+# Sessions
 SESSION_SECRET=your_super_secret_session_key_min_32_chars
+
+# GitHub OAuth (or GitHub App — see Scopes & Browsing Reality)
 GITHUB_CLIENT_ID=your_github_oauth_app_client_id
-GITHUB_CLIENT_ID
 GITHUB_CLIENT_SECRET=your_github_oauth_app_client_secret
+GITHUB_REDIRECT_URI=http://localhost:3000/api/auth/github/callback
+
+# Google OAuth (+ Picker API key for client-side folder selection)
 GOOGLE_CLIENT_ID=your_google_oauth_client_id
 GOOGLE_CLIENT_SECRET=your_google_oauth_client_secret
 GOOGLE_REDIRECT_URI=http://localhost:3000/api/auth/google/callback
-GITHUB_REDIRECT_URI=http://localhost:3000/api/auth/github/callback
+GOOGLE_PICKER_API_KEY=your_google_picker_browser_api_key
 
-# Encryption (generate with: openssl rand -base64 32)
+# Token encryption at rest (generate with: openssl rand -base64 32)
 ENCRYPTION_KEY=your_32_byte_base64_encoded_encryption_key
 ```
 
@@ -235,16 +479,20 @@ ENCRYPTION_KEY=your_32_byte_base64_encoded_encryption_key
 
 ## OAuth App Configuration
 
-### GitHub OAuth App
-1. Settings → Developer settings → OAuth Apps → New OAuth App
-2. Authorization callback URL: `http://localhost:3000/api/auth/github/callback`
-3. Scopes: `repo`, `user:email`
+### GitHub
+- **OAuth App**: callback `http://localhost:3000/api/auth/github/callback`;
+  scopes `repo` (private) **or** `public_repo` (public-only), plus `read:user`.
+- **GitHub App (recommended for least privilege)**: permissions
+  `Contents: read/write`, `Metadata: read`; users install on selected repos.
 
-### Google OAuth Client
-1. Google Cloud Console → APIs & Services → Credentials
-2. Create OAuth 2.0 Client ID (Web application)
-3. Authorized redirect URI: `http://localhost:3000/api/auth/google/callback`
-4. Scopes: `https://www.googleapis.com/auth/drive.file`, `profile`, `email`
+### Google
+1. Cloud Console → APIs & Services → enable **Drive API** and **Picker API**.
+2. OAuth 2.0 Client ID (Web): redirect
+   `http://localhost:3000/api/auth/google/callback`.
+3. Scopes: `openid email profile` + `https://www.googleapis.com/auth/drive.file`
+   (Picker flow). Only add `drive.metadata.readonly` if doing app-rendered
+   browsing.
+4. Create a browser API key for the Picker (`GOOGLE_PICKER_API_KEY`).
 
 ---
 
@@ -252,64 +500,91 @@ ENCRYPTION_KEY=your_32_byte_base64_encoded_encryption_key
 
 ### GitHub (Octokit)
 ```js
-// ✅ Correct - get repository by owner/repo
-const { data } = await octokit.repos.get({ owner, repo });
+// List repos the user can write (for the picker)
+await octokit.repos.listForAuthenticatedUser({ visibility: 'all', per_page: 100 });
 
-// ✅ Correct - create repository for authenticated user
+// Existence / fit-check read — get the manifest blob
+await octokit.repos.getContent({ owner, repo, path: 'equalview.json' }); // 404 ⇒ no manifest
+
+// Create a repo for the "new" path
 await octokit.repos.createForAuthenticatedUser({ name, private: true });
 
-// ✅ Correct - create or update file
-await octokit.repos.createOrUpdateFileContents({ owner, repo, path, message, content, branch });
+// Atomic-ish write (pass sha to update; omit to create)
+await octokit.repos.createOrUpdateFileContents({ owner, repo, path, message, content, branch, sha });
 ```
 
 ### Google Drive (googleapis)
 ```js
-// ✅ Correct - OAuth2 client with access token
+// OAuth2 client with the decrypted access token
 const oauth2 = new google.auth.OAuth2();
 oauth2.setCredentials({ access_token: decryptedToken });
 const drive = google.drive({ version: 'v3', auth: oauth2 });
 
-// ✅ Correct - create folder
-await drive.files.create({ resource: { name, mimeType: 'application/vnd.google-apps.folder', parents: [parentId] }, fields: 'id,name,webViewLink' });
+// Read the manifest inside the picked folder (fit-check)
+await drive.files.list({ q: `'${folderId}' in parents and name = 'equalview.json' and trashed = false`,
+                         fields: 'files(id,name,modifiedTime)' });
 
-// ✅ Correct - upload file
-await drive.files.create({ resource: { name, parents: [folderId] }, media: { mimeType, body: content }, fields: 'id,name,webViewLink,size' });
+// Create a folder (the "new" path)
+await drive.files.create({ resource: { name, mimeType: 'application/vnd.google-apps.folder' },
+                           fields: 'id,name,webViewLink' });
+
+// Upload / update a file (use generation preconditions on update)
+await drive.files.create({ resource: { name, parents: [folderId] },
+                           media: { mimeType, body: content }, fields: 'id,name,webViewLink' });
 ```
 
 ---
 
 ## Acceptance Criteria
 
-- ✅ Users can sign in with GitHub (OAuth flow)
-- ✅ Users can sign in with Google (OAuth flow)
-- ✅ User sessions remain valid and are handled securely (express-session + secure cookies + encrypted tokens)
-- ✅ GitHub repository creation works (Octokit `repos.createForAuthenticatedUser`)
-- ✅ Google Drive folder creation works (googleapis `drive.files.create`)
-- ✅ Scan results saved to GitHub repo (`repos.createOrUpdateFileContents` to `scans/{hostname}_{timestamp}.json`)
-- ✅ Scan results saved to Google Drive folder (`drive.files.create` to folder)
-- ✅ Appropriate error messages on auth/storage failures
-- ✅ Backend endpoints documented and tested
-- ⚠️ **Frontend changes ARE required** — this design includes frontend integration (see TODO.md)
+- ✅ Sign in with GitHub and Google (OAuth, encrypted tokens, secure session).
+- ✅ After OAuth, the user **sees real storage** they can use — GitHub repos via
+  the API, Drive folders via Google Picker — plus a "create new" option.
+- ✅ Selecting a storage runs a **fit-check** that returns `loadable` /
+  `initializable` / `unrelated` / `incompatible` / `invalid` with capabilities.
+- ✅ `loadable` storage **rehydrates the full account** (settings + scan index),
+  reconciling any index drift.
+- ✅ `initializable` / new storage is **set up** atomically (manifest + `scans/`).
+- ✅ New scans by an authenticated user are **appended atomically** to their
+  storage; a storage failure never fails the scan response.
+- ✅ Scan files are immutable; the index/`scanCount` are caches rebuildable from
+  disk.
+- ⚠️ **Frontend changes ARE required** (real ConnectView picker + validation).
+- ⚠️ Scope tradeoffs (GitHub `repo` breadth; Google browsing) are **disclosed in
+  the UI**, not just the docs.
 
 ---
 
 ## Troubleshooting
 
 | Issue | Cause | Solution |
-|-------|-------|----------|
-| `redirect_uri_mismatch` | OAuth callback URL mismatch | Verify `.env` redirect URIs match OAuth app console exactly |
-| `InvalidKeyException` / `BadPaddingException` | Invalid encryption key | Ensure `ENCRYPTION_KEY` is 32-byte base64 (`openssl rand -base64 32`) |
-| `403 Rate Limit Exceeded` | GitHub/Google API rate limits | Implement exponential backoff, cache tokens |
-| `403 Insufficient Permissions` | Missing OAuth scopes | Verify requested scopes match app requirements |
-| Session not persisting | Missing `credentials: 'include'` | Ensure all fetch calls include credentials |
+| --- | --- | --- |
+| `redirect_uri_mismatch` | Callback URL mismatch | Make `.env` redirect URIs match the OAuth console exactly |
+| Can't list Drive folders | Using `drive.file` (app-only) | Use Google Picker, or add `drive.metadata.readonly` |
+| GitHub picker missing private repos | `public_repo` scope | Use `repo` scope or a GitHub App with selected repos |
+| `InvalidKey` / `BadPadding` | Bad `ENCRYPTION_KEY` | 32-byte base64 (`openssl rand -base64 32`) |
+| Fit-check says `invalid` on a real store | Malformed/duplicate `equalview.json` | Inspect manifest; on Drive remove duplicate manifest files |
+| Scans appear/disappear across devices | Index drift / concurrent writes | Load-time reconcile rebuilds index from `scans/*.json` |
+| Lost scan after a failed write | Partial multi-file write | Expected — scan files are truth; re-run reconcile |
+| `403 Rate Limit` | API limits | Backoff; cache the manifest within a session |
+| Session not persisting | Missing `credentials: 'include'` | Ensure every fetch includes credentials |
 
 ---
 
+## Relationship to the roadmap
+
+This supersedes the **Postgres + JWT** sketch in
+[`../../plans/project-roadmap.md`](../../plans/project-roadmap.md) Phase 5: there
+is **no project database**. The placeholder UI already assumes user-owned
+storage; this design makes it real. If a future phase needs server-side
+persistence (e.g. team features), it is additive — the portable store stays the
+user's source of truth.
+
 ## Future Enhancements
 
-1. **Database Persistence**: Replace in-memory session with PostgreSQL/MongoDB
-2. **Auto Token Refresh**: Background Google token refresh before expiry
-3. **Storage Metrics**: Track usage per user
-4. **Additional Providers**: Bitbucket, GitLab, Dropbox
-5. **Advanced GitHub**: Issues, Projects, Actions integration
-6. **Google Workspace**: Sheets/Docs for reports
+1. **Subject-bound mode** — optional policy to reject load when OAuth subject ≠
+   `storage.ownerId`.
+2. **Auto token refresh** before expiry (Google).
+3. **More providers** — GitLab, Bitbucket, Dropbox (same contract).
+4. **Conflict UI** — when two devices diverge, show a merge/repair screen.
+5. **Export/import** — move an account between providers by copying the store.


### PR DESCRIPTION
## Why this PR
Our earlier auth/storage design treated storage as a **sink** — sign in, then dump scan files into a repo/folder. That framing quietly implied a project DB (Postgres + JWT in the Phase 5 roadmap) and left the hard parts undefined: what's actually on
disk, how devices reconcile, and how "browse your existing storage" really works per provider.

This PR reframes it: **the user's own GitHub repo / Google Drive folder *is* the account.** OAuth is only an identity + API-token handshake; the store is the source of truth. That single shift is what makes EqualView cheap to run (zero per-user server
state), portable (sign in on any device, pick the same storage, load your account back), and honest about provider scope tradeoffs.

## What changed (docs only — no code)
- **New `accountStorageContract.md`** — the authoritative on-disk spec: `equalview.json` manifest + immutable `scans/`, rebuildable caches, optimistic-concurrency and drift-repair rules.
- **Rewrote the design doc** — the `browse → select → validate (fit-check) → load-or-init` flow, the `drive.file`/Google Picker reality, GitHub scope tradeoffs, and the possession-based identity model.
- **Rewrote `TODO.md`** — Phase 0 decisions to lock first + an updated verification checklist.
- **`CHANGELOG.md`** — side-by-side of the old vs. new design and the reasoning.
- **`AGENTS.md` / `CLAUDE.md`** — persist this architecture + the auth/storage non-negotiables so any agent picking up this long-horizon work stays aligned instead of reintroducing a DB or writing tokens into the store.

## Non-negotiables it locks in
No project DB. No tokens/secrets in the store. Possession-based identity by default.
Scope tradeoffs disclosed in the UI, not buried in docs.

## Scope
Design + docs only. Implementation is tracked in `TODO.md` and lands in follow-up PRs.