### PR TITLE
Fix production 500s: build the API as a traced function

### DIFF
--- a/api/index.js
+++ b/api/index.js
@@ -1,0 +1,66 @@
+/**
+ * Vercel serverless entry — one function for the whole API.
+ *
+ * By itself this file only answers `/api` exactly; Vercel's `api/` directory
+ * maps file paths to URL paths and supports a single dynamic segment, not
+ * arbitrary depth. Catch-all filenames like `[...path].js` are a Next.js
+ * convention and do not apply here. The `/api/(.*)` rewrite in vercel.json is
+ * what routes every nested path to this function, which is the pattern
+ * Vercel's own Express guide uses.
+ *
+ * No `serverless-http` wrapper: Vercel's Node runtime invokes the export as
+ * `(req, res)`, which is precisely an Express app's signature.
+ */
+const { buildApp } = require('../backend/app');
+
+// app.js exports the buildApp *factory*, not an assembled app — it takes an
+// overrides object so tests can inject fakes. index.js, which holds these
+// guards and the listen call, is only used by local dev and never loads here.
+if (!process.env.SESSION_SECRET) {
+  throw new Error('SESSION_SECRET is required');
+}
+if (!process.env.ENCRYPTION_KEY) {
+  throw new Error('ENCRYPTION_KEY is required');
+}
+
+// Built once at module scope so warm invocations reuse it.
+const app = buildApp();
+
+/** Query key the vercel.json rewrite uses to carry the real path through. */
+const PATH_PARAM = '__vzpath';
+
+/**
+ * Restore the pre-rewrite request path.
+ *
+ * Express routes on `req.url`, so it has to see `/api/auth/status` rather than
+ * the rewrite destination. Reports differ on whether Vercel forwards the
+ * original path or the rewritten one, and `vercel dev` is known to differ from
+ * production here — so rather than depend on that, the rewrite carries the
+ * path explicitly and this puts it back. Both behaviours end up identical, and
+ * the marker is stripped so handlers never see it.
+ *
+ * @param {string} url raw `req.url`
+ * @returns {string} the URL Express should route on
+ */
+function restorePath(url) {
+  const parsed = new URL(url, 'http://localhost');
+  const carried = parsed.searchParams.get(PATH_PARAM);
+
+  // Only a request flattened onto /api can have lost its path, so the marker
+  // is read there and nowhere else. A client may send the same parameter, but
+  // on any other path it is stripped and ignored rather than allowed to steer
+  // routing. (Even when honoured it only aliases a path the caller could have
+  // requested directly — every route authenticates on its own.)
+  const wasFlattened = parsed.pathname === '/api' && carried !== null;
+
+  parsed.searchParams.delete(PATH_PARAM);
+  const query = parsed.searchParams.toString();
+  const pathname = wasFlattened ? `/api/${carried}` : parsed.pathname;
+
+  return `${pathname}${query ? `?${query}` : ''}`;
+}
+
+module.exports = (req, res) => {
+  req.url = restorePath(req.url);
+  return app(req, res);
+};

--- a/backend/README.md
+++ b/backend/README.md
@@ -211,25 +211,27 @@ prefix; anything outside it is answered by the static SPA instead.
 
 ## Deploying to Vercel
 
-The repo deploys as **one Vercel project containing two services** — Vercel's
-native model for a frontend and a backend in the same repository. It detects
-both automatically: `frontend/` as Vite, `backend/` as Express.
+The frontend builds to a static bundle and the whole Express app runs as one
+function at [`api/index.js`](../api/index.js), built by `@vercel/node`.
 
 ```
 request -> filesystem (real static assets win)
-        -> /api/*  -> backend service   (backend/index.js, unchanged)
-        -> /*      -> frontend service  (frontend/dist, SPA fallback)
+        -> /api/*  -> the function   (Express, via the /api rewrite)
+        -> /*      -> index.html     (SPA fallback)
 ```
 
-`backend/index.js` needs no changes. Vercel supports the `app.listen()` pattern
-and wraps it, reporting `Using index.js as the root entrypoint` at build time.
-There is no `api/` directory, no wrapper module, and no `serverless-http`.
+**Do not switch this to Vercel's `services` model**, even though the CLI
+detects `frontend/` as Vite and `backend/` as Express and will offer to. That
+path builds the backend by *bundling* it with rolldown, which wrapped
+`app.js` in a lazy CommonJS shim and handed the entry an empty object — every
+route returned 500 with `buildApp is not a function`, and no export shape fixed
+it. `@vercel/node` **traces and copies** files instead, so the code that runs is
+the code you wrote. The tell, if it ever regresses: local modules fail to
+resolve inside the function while npm packages resolve fine.
 
-**A service receives the original path.** `GET /api/auth/status` arrives at
-Express as `/api/auth/status`, not `/auth/status`, so the existing route mounts
-work as they do locally. Routing into a service is also final: if nothing
-inside matches, Vercel returns that service's 404 rather than falling through
-to the other service.
+`framework: null` in `vercel.json` is load-bearing — it overrides the project's
+framework preset, which Vercel pins to `services` the moment you link with
+services declared.
 
 Set these in the Vercel dashboard for **Production and Preview** — never in
 `vercel.json`, which is public config and holds no values:
@@ -267,18 +269,28 @@ vercel dev      # serves them together
 
 ### Verified against a real build
 
-Confirmed by inspecting `.vercel/output`, not assumed:
+Confirmed on a preview deployment and by inspecting `.vercel/output`, not
+assumed:
 
-- Output is `services/backend/functions/index.func` plus
-  `services/frontend/static`. A CLI warning about "no functions or static
-  directory" is a false alarm in services mode.
-- `maxDuration: 60` reaches the built function config. The `functions` key is a
-  **glob scoped to the service** — an earlier bracketed filename matched
-  nothing and silently left the function on the plan default of 300s.
-- Runtime resolves to `nodejs24.x` from `engines.node` in
-  `backend/package.json`. `@sparticuz/chromium` requires **Node ≥ 22.17**, so
-  this matters; `frontend/` and `backend/` stay separate packages with their
-  own lockfiles.
+- `/health`, `/api/auth/status` and `/api/problems/:id` return 200,
+  `/api/scans` 401s while unauthenticated, `/dashboard` falls through to the
+  SPA, and `POST /api/scan` completes a real Chromium scan returning axe-core
+  results.
+- The function's `backend/` directory contains `app.js` — plain traced source.
+  If it ever contains `app.cjs` instead, something has switched it back to a
+  bundled build and the API will break.
+- **`@octokit/rest` is pinned to 20.1.1, the last CommonJS release.** v21+ are
+  ESM-only, and Vercel precompiles functions to bytecode, a path that cannot
+  `require()` an ES module even on Node 24, where plain `node` can. Locally the
+  same `require` works, so an upgrade here passes every test and then fails
+  only in production. Every endpoint used (repos, git, apps, users) is
+  unchanged in 20.x.
+- `maxDuration: 60` reaches the built function config; the `functions` key is a
+  **glob**, and an earlier bracketed filename matched nothing and silently left
+  the function on the plan default of 300s.
+- Runtime resolves to `nodejs24.x`. `@sparticuz/chromium` requires
+  **Node ≥ 22.17**, so this matters; `frontend/` and `backend/` stay separate
+  packages with their own lockfiles.
 - `memory` cannot be set in `vercel.json` once Fluid compute is on (dashboard
   only), and Hobby's default is already its 2GB maximum.
 - `app.set('trust proxy', 1)` in `app.js` is required, not cosmetic. Vercel

--- a/backend/app.js
+++ b/backend/app.js
@@ -64,4 +64,8 @@ function buildApp(overrides = {}) {
   return app;
 }
 
-module.exports = buildApp;
+// A named export rather than `module.exports = buildApp`. A bare function
+// export has no single agreed shape once anything tries to bridge CommonJS and
+// ESM — it becomes `.default` in some toolchains and the function itself in
+// others. Naming it removes that ambiguity for every consumer.
+exports.buildApp = buildApp;

--- a/backend/index.js
+++ b/backend/index.js
@@ -11,7 +11,7 @@ if (!process.env.ENCRYPTION_KEY) {
   throw new Error('ENCRYPTION_KEY is required');
 }
 
-const buildApp = require('./app');
+const { buildApp } = require('./app');
 
 const PORT = process.env.PORT || 3000;
 

--- a/backend/package-lock.json
+++ b/backend/package-lock.json
@@ -9,7 +9,7 @@
       "version": "1.0.0",
       "license": "MPL-2.0",
       "dependencies": {
-        "@octokit/rest": "^22.0.1",
+        "@octokit/rest": "^20.1.1",
         "@sparticuz/chromium": "^148.0.0",
         "axe-core": "^4.10.2",
         "cookie-session": "^2.1.1",
@@ -70,171 +70,158 @@
       }
     },
     "node_modules/@octokit/auth-token": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-6.0.0.tgz",
-      "integrity": "sha512-P4YJBPdPSpWTQ1NU4XYdvHvXJJDxM6YwpS0FZHRgP7YFkdVxsWcpWGy/NVqlAA7PcPCnMacXlRm1y2PFZRWL/w==",
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/@octokit/auth-token/-/auth-token-4.0.0.tgz",
+      "integrity": "sha512-tY/msAuJo6ARbK6SPIxZrPBms3xPbfwBrulZe0Wtr/DIY9lje2HeV1uoebShn6mx7SjCHif6EjMvoREj+gZ+SA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/core": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-7.0.6.tgz",
-      "integrity": "sha512-DhGl4xMVFGVIyMwswXeyzdL4uXD5OGILGX5N8Y+f6W7LhC1Ze2poSNrkF/fedpVDHEEZ+PHFW0vL14I+mm8K3Q==",
+      "version": "5.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/core/-/core-5.2.2.tgz",
+      "integrity": "sha512-/g2d4sW9nUDJOMz3mabVQvOGhVa4e/BN/Um7yca9Bb2XTzPPnfTWHWQg+IsEYO7M3Vx+EXvaM/I2pJWIMun1bg==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/auth-token": "^6.0.0",
-        "@octokit/graphql": "^9.0.3",
-        "@octokit/request": "^10.0.6",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "before-after-hook": "^4.0.0",
-        "universal-user-agent": "^7.0.0"
+        "@octokit/auth-token": "^4.0.0",
+        "@octokit/graphql": "^7.1.0",
+        "@octokit/request": "^8.4.1",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.0.0",
+        "before-after-hook": "^2.2.0",
+        "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/endpoint": {
-      "version": "11.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-11.0.3.tgz",
-      "integrity": "sha512-FWFlNxghg4HrXkD3ifYbS/IdL/mDHjh9QcsNyhQjN8dplUoZbejsdpmuqdA76nxj2xoWPs7p8uX2SNr9rYu0Ag==",
+      "version": "9.0.6",
+      "resolved": "https://registry.npmjs.org/@octokit/endpoint/-/endpoint-9.0.6.tgz",
+      "integrity": "sha512-H1fNTMA57HbkFESSt3Y9+FBICv+0jFceJFPWDePYlR/iMGrwM5ph+Dd4XRQs+8X+PUFURLQgX9ChPfhJ/1uNQw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.2"
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/graphql": {
-      "version": "9.0.3",
-      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-9.0.3.tgz",
-      "integrity": "sha512-grAEuupr/C1rALFnXTv6ZQhFuL1D8G5y8CN04RgrO4FIPMrtm+mcZzFG7dcBm+nq+1ppNixu+Jd78aeJOYxlGA==",
+      "version": "7.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/graphql/-/graphql-7.1.1.tgz",
+      "integrity": "sha512-3mkDltSfcDUoa176nlGoA32RGjeWjl3K7F/BwHwRMJUW/IteSa4bnSV8p2ThNkcIcZU2umkZWxwETSSCJf2Q7g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/request": "^10.0.6",
-        "@octokit/types": "^16.0.0",
-        "universal-user-agent": "^7.0.0"
+        "@octokit/request": "^8.4.1",
+        "@octokit/types": "^13.0.0",
+        "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/openapi-types": {
-      "version": "27.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-27.0.0.tgz",
-      "integrity": "sha512-whrdktVs1h6gtR+09+QsNk2+FO+49j6ga1c55YZudfEG+oKJVvJLQi3zkOm5JjiUXAagWK2tI2kTGKJ2Ys7MGA==",
+      "version": "24.2.0",
+      "resolved": "https://registry.npmjs.org/@octokit/openapi-types/-/openapi-types-24.2.0.tgz",
+      "integrity": "sha512-9sIH3nSUttelJSXUrmGzl7QUBFul0/mB8HRYl3fOlgHbIWG+WnYDXU3v/2zMtAvuzZ/ed00Ei6on975FhBfzrg==",
       "license": "MIT"
     },
     "node_modules/@octokit/plugin-paginate-rest": {
-      "version": "14.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-14.0.0.tgz",
-      "integrity": "sha512-fNVRE7ufJiAA3XUrha2omTA39M6IXIc6GIZLvlbsm8QOQCYvpq/LkMNGyFlB1d8hTDzsAXa3OKtybdMAYsV/fw==",
+      "version": "11.3.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-paginate-rest/-/plugin-paginate-rest-11.3.1.tgz",
+      "integrity": "sha512-ryqobs26cLtM1kQxqeZui4v8FeznirUsksiA+RYemMPJ7Micju0WSkv50dBksTuZks9O5cg4wp+t8fZ/cLY56g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0"
+        "@octokit/types": "^13.5.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=6"
+        "@octokit/core": "5"
       }
     },
     "node_modules/@octokit/plugin-request-log": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-6.0.0.tgz",
-      "integrity": "sha512-UkOzeEN3W91/eBq9sPZNQ7sUBvYCqYbrrD8gTbBuGtHEuycE4/awMXcYvx6sVYo7LypPhmQwwpUe4Yyu4QZN5Q==",
+      "version": "4.0.1",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-request-log/-/plugin-request-log-4.0.1.tgz",
+      "integrity": "sha512-GihNqNpGHorUrO7Qa9JbAl0dbLnqJVrV8OXe2Zm5/Y4wFkZQDfTreBzVmiRfJVfE4mClXdihHnbpyyO9FSX4HA==",
       "license": "MIT",
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=6"
+        "@octokit/core": "5"
       }
     },
     "node_modules/@octokit/plugin-rest-endpoint-methods": {
-      "version": "17.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-17.0.0.tgz",
-      "integrity": "sha512-B5yCyIlOJFPqUUeiD0cnBJwWJO8lkJs5d8+ze9QDP6SvfiXSz1BF+91+0MeI1d2yxgOhU/O+CvtiZ9jSkHhFAw==",
+      "version": "13.2.2",
+      "resolved": "https://registry.npmjs.org/@octokit/plugin-rest-endpoint-methods/-/plugin-rest-endpoint-methods-13.2.2.tgz",
+      "integrity": "sha512-EI7kXWidkt3Xlok5uN43suK99VWqc8OaIMktY9d9+RNKl69juoTyxmLoWPIZgJYzi41qj/9zU7G/ljnNOJ5AFA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0"
+        "@octokit/types": "^13.5.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       },
       "peerDependencies": {
-        "@octokit/core": ">=6"
+        "@octokit/core": "^5"
       }
     },
     "node_modules/@octokit/request": {
-      "version": "10.0.11",
-      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-10.0.11.tgz",
-      "integrity": "sha512-+s7HUxjfFqOMS9VlIwDffq0MikjSAK0gSpG73W+meAvVAvX4MBrHYTK5Bj3Uot55qFT4gzUtfzE4mGWY4Br8/Q==",
+      "version": "8.4.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request/-/request-8.4.1.tgz",
+      "integrity": "sha512-qnB2+SY3hkCmBxZsR/MPCybNmbJe4KAlfWErXq+rBKkQJlbjdJeS85VI9r8UqeLYLvnAenU8Q1okM/0MBsAGXw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/endpoint": "^11.0.3",
-        "@octokit/request-error": "^7.0.2",
-        "@octokit/types": "^16.0.0",
-        "content-type": "^2.0.0",
-        "json-with-bigint": "^3.5.3",
-        "universal-user-agent": "^7.0.2"
+        "@octokit/endpoint": "^9.0.6",
+        "@octokit/request-error": "^5.1.1",
+        "@octokit/types": "^13.1.0",
+        "universal-user-agent": "^6.0.0"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/request-error": {
-      "version": "7.1.0",
-      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-7.1.0.tgz",
-      "integrity": "sha512-KMQIfq5sOPpkQYajXHwnhjCC0slzCNScLHs9JafXc4RAJI+9f+jNDlBNaIMTvazOPLgb4BnlhGJOTbnN0wIjPw==",
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/request-error/-/request-error-5.1.1.tgz",
+      "integrity": "sha512-v9iyEQJH6ZntoENr9/yXxjuezh4My67CBSu9r6Ve/05Iu5gNgnisNWOsoJHTP6k0Rr0+HQIpnH+kyammu90q/g==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/types": "^16.0.0"
+        "@octokit/types": "^13.1.0",
+        "deprecation": "^2.0.0",
+        "once": "^1.4.0"
       },
       "engines": {
-        "node": ">= 20"
-      }
-    },
-    "node_modules/@octokit/request/node_modules/content-type": {
-      "version": "2.0.0",
-      "resolved": "https://registry.npmjs.org/content-type/-/content-type-2.0.0.tgz",
-      "integrity": "sha512-j/O/d7GcZCyNl7/hwZAb606rzqkyvaDctLmckbxLzHvFBzTJHuGEdodATcP3yIRoDrLHkIATJuvzbFlp/ki2cQ==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "type": "opencollective",
-        "url": "https://opencollective.com/express"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/rest": {
-      "version": "22.0.1",
-      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-22.0.1.tgz",
-      "integrity": "sha512-Jzbhzl3CEexhnivb1iQ0KJ7s5vvjMWcmRtq5aUsKmKDrRW6z3r84ngmiFKFvpZjpiU/9/S6ITPFRpn5s/3uQJw==",
+      "version": "20.1.1",
+      "resolved": "https://registry.npmjs.org/@octokit/rest/-/rest-20.1.1.tgz",
+      "integrity": "sha512-MB4AYDsM5jhIHro/dq4ix1iWTLGToIGk6cWF5L6vanFaMble5jTX/UBQyiv05HsWnwUtY8JrfHy2LWfKwihqMw==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/core": "^7.0.6",
-        "@octokit/plugin-paginate-rest": "^14.0.0",
-        "@octokit/plugin-request-log": "^6.0.0",
-        "@octokit/plugin-rest-endpoint-methods": "^17.0.0"
+        "@octokit/core": "^5.0.2",
+        "@octokit/plugin-paginate-rest": "11.3.1",
+        "@octokit/plugin-request-log": "^4.0.0",
+        "@octokit/plugin-rest-endpoint-methods": "13.2.2"
       },
       "engines": {
-        "node": ">= 20"
+        "node": ">= 18"
       }
     },
     "node_modules/@octokit/types": {
-      "version": "16.0.0",
-      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-16.0.0.tgz",
-      "integrity": "sha512-sKq+9r1Mm4efXW1FCk7hFSeJo4QKreL/tTbR0rz/qx/r1Oa2VV83LTA/H/MuCOX7uCIJmQVRKBcbmWoySjAnSg==",
+      "version": "13.10.0",
+      "resolved": "https://registry.npmjs.org/@octokit/types/-/types-13.10.0.tgz",
+      "integrity": "sha512-ifLaO34EbbPj0Xgro4G5lP5asESjwHracYJvVaPIyXMuiuXLlhic3S47cBdTb+jfODkTE5YtGCLt3Ay3+J97sA==",
       "license": "MIT",
       "dependencies": {
-        "@octokit/openapi-types": "^27.0.0"
+        "@octokit/openapi-types": "^24.2.0"
       }
     },
     "node_modules/@paralleldrive/cuid2": {
@@ -674,9 +661,9 @@
       }
     },
     "node_modules/before-after-hook": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-4.0.0.tgz",
-      "integrity": "sha512-q6tR3RPqIB1pMiTRMFcZwuG5T8vwp+vUvEG0vuI6B+Rikh5BfPp2fQ82c925FOs+b0lcFQ8CFrL+KbilfZFhOQ==",
+      "version": "2.2.3",
+      "resolved": "https://registry.npmjs.org/before-after-hook/-/before-after-hook-2.2.3.tgz",
+      "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "license": "Apache-2.0"
     },
     "node_modules/binary-extensions": {
@@ -1078,6 +1065,12 @@
       "engines": {
         "node": ">= 0.8"
       }
+    },
+    "node_modules/deprecation": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/deprecation/-/deprecation-2.3.1.tgz",
+      "integrity": "sha512-xmHIy4F3scKVwMsQ4WnVaS8bHOx0DmVwRywosKhaILI0ywMDWPtBSku2HNxRvF7jtwDRsoEwYQSfbxj8b7RlJQ==",
+      "license": "ISC"
     },
     "node_modules/devtools-protocol": {
       "version": "0.0.1608973",
@@ -1885,12 +1878,6 @@
       "resolved": "https://registry.npmjs.org/json-parse-even-better-errors/-/json-parse-even-better-errors-2.3.1.tgz",
       "integrity": "sha512-xyFwyhro/JEof6Ghe2iz2NcXoj2sloNsWr/XsERDK/oiPCfaNhl5ONfp+jQdAZRQQ0IJWNzH9zIZF7li91kh2w==",
       "dev": true,
-      "license": "MIT"
-    },
-    "node_modules/json-with-bigint": {
-      "version": "3.5.8",
-      "resolved": "https://registry.npmjs.org/json-with-bigint/-/json-with-bigint-3.5.8.tgz",
-      "integrity": "sha512-eq/4KP6K34kwa7TcFdtvnftvHCD9KvHOGGICWwMFc4dOOKF5t4iYqnfLK8otCRCRv06FXOzGGyqE8h8ElMvvdw==",
       "license": "MIT"
     },
     "node_modules/keygrip": {
@@ -2952,9 +2939,9 @@
       "license": "MIT"
     },
     "node_modules/universal-user-agent": {
-      "version": "7.0.3",
-      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-7.0.3.tgz",
-      "integrity": "sha512-TmnEAEAsBJVZM/AADELsK76llnwcf9vMKuPz8JflO1frO8Lchitr0fNaN9d+Ap0BjKtqWqd/J17qeDnXh8CL2A==",
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/universal-user-agent/-/universal-user-agent-6.0.1.tgz",
+      "integrity": "sha512-yCzhz6FN2wU1NiiQRogkTQszlQSlpWaw8SvVegAc+bDxbzHgh1vX8uIe8OYyMH6DwH+sdTJsgMl36+mSMdRJIQ==",
       "license": "ISC"
     },
     "node_modules/unpipe": {

--- a/backend/package.json
+++ b/backend/package.json
@@ -15,7 +15,7 @@
     "node": "24.x"
   },
   "dependencies": {
-    "@octokit/rest": "^22.0.1",
+    "@octokit/rest": "^20.1.1",
     "@sparticuz/chromium": "^148.0.0",
     "axe-core": "^4.10.2",
     "cookie-session": "^2.1.1",

--- a/backend/tests/auth.test.js
+++ b/backend/tests/auth.test.js
@@ -6,7 +6,7 @@ const assert = require('node:assert/strict');
 const request = require('supertest');
 
 const { TEST_ENCRYPTION_KEY, TEST_SESSION_SECRET } = require('./helpers/testEnv');
-const buildApp = require('../app');
+const { buildApp } = require('../app');
 const AuthService = require('../services/authService');
 const StorageService = require('../services/storageService');
 

--- a/backend/tests/dependencies.test.js
+++ b/backend/tests/dependencies.test.js
@@ -1,0 +1,30 @@
+/**
+ * Guards on dependency shape that only fail in production otherwise.
+ */
+const test = require('node:test');
+const assert = require('node:assert/strict');
+const fs = require('node:fs');
+const path = require('node:path');
+
+/** @param {string} name */
+function readInstalledPackageJson(name) {
+  const pkgPath = path.join(__dirname, '..', 'node_modules', ...name.split('/'), 'package.json');
+  return JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+}
+
+test('@octokit/rest ships a CommonJS entry', () => {
+  // v21+ are ESM-only. Vercel precompiles functions to bytecode, and that path
+  // cannot require() an ES module even on Node 24 — where plain `node` can, so
+  // an upgrade passes this whole suite locally and then 500s every route in
+  // production. Pinned to the last CommonJS release; see backend/README.md.
+  const pkg = readInstalledPackageJson('@octokit/rest');
+  const hasCommonJsEntry =
+    Boolean(pkg.main) || Boolean(pkg.exports?.['.']?.require);
+
+  assert.ok(
+    hasCommonJsEntry,
+    `@octokit/rest@${pkg.version} is ESM-only, which Vercel cannot require(). ` +
+      'Stay on the 20.x line, or convert the Octokit call sites to dynamic ' +
+      'import() before upgrading.',
+  );
+});

--- a/backend/tests/health.test.js
+++ b/backend/tests/health.test.js
@@ -7,7 +7,7 @@ const assert = require('node:assert/strict');
 const request = require('supertest');
 
 require('./helpers/testEnv');
-const buildApp = require('../app');
+const { buildApp } = require('../app');
 
 test('GET /health returns 200 with status payload', async () => {
   const app = buildApp();

--- a/backend/tests/scan.test.js
+++ b/backend/tests/scan.test.js
@@ -7,7 +7,7 @@ const assert = require('node:assert/strict');
 const request = require('supertest');
 
 require('./helpers/testEnv');
-const buildApp = require('../app');
+const { buildApp } = require('../app');
 const mockScanResults = require('../data/mockScanResults');
 
 const mockScanRunner = {

--- a/vercel.json
+++ b/vercel.json
@@ -3,26 +3,23 @@
   "git": {
     "deploymentEnabled": false
   },
-  "services": {
-    "frontend": {
-      "root": "frontend/",
-      "framework": "vite",
-      "rewrites": [
-        { "source": "/(.*)", "destination": "/index.html" }
-      ]
-    },
-    "backend": {
-      "root": "backend/",
-      "framework": "express",
-      "functions": {
-        "**": {
-          "maxDuration": 60
-        }
-      }
+  "installCommand": "npm --prefix frontend install && npm --prefix backend install",
+  "buildCommand": "npm --prefix frontend run build",
+  "outputDirectory": "frontend/dist",
+  "functions": {
+    "api/**": {
+      "maxDuration": 60
     }
   },
   "rewrites": [
-    { "source": "/api/(.*)", "destination": { "service": "backend" } },
-    { "source": "/(.*)", "destination": { "service": "frontend" } }
-  ]
+    {
+      "source": "/api/(.*)",
+      "destination": "/api?__vzpath=$1"
+    },
+    {
+      "source": "/(.*)",
+      "destination": "/index.html"
+    }
+  ],
+  "framework": null
 }


### PR DESCRIPTION
Fixes the production 500s. `vizably.vercel.app` served the frontend but every `/api/*` route failed with `FUNCTION_INVOCATION_FAILED`, reporting `TypeError: buildApp is not a function`.

## Root cause, two layers deep

**Vercel's `services` model bundles the backend, and the bundling broke it.** The CLI detects `frontend/` as Vite and `backend/` as Express and builds the backend by bundling it with rolldown. That wrapped `app.js` in a lazy CommonJS shim which handed the entry an empty object, so the export looked absent no matter what shape it took — changing it to a named export twice made no difference.

A diagnostic deployment showed why. Inside the deployed function, every local module failed to resolve while npm packages resolved fine:

```
./app                -> THREW Cannot find module './app'
./services/ssrfGuard -> THREW Cannot find module './services/ssrfGuard'
express              -> function
```

That is the signature of a bundle, not of missing files.

**Underneath it sat the real incompatibility.** `@octokit/rest` v22 is ESM-only — its exports map has no CommonJS entry at all. Vercel precompiles functions to bytecode, and that path cannot `require()` an ES module even on Node 24, where plain `node` can. Locally the same `require` works, which is why this passed the full suite and failed only once deployed.

## The fix

The API now builds through `@vercel/node`, which traces and copies files rather than bundling them, so the code that runs is the code that was written. `@octokit/rest` is pinned to 20.1.1, the last CommonJS release; every endpoint in use (repos, git, apps, users) is unchanged in that line.

`framework: null` in `vercel.json` is load-bearing — it overrides the project's framework preset, which Vercel pins to `services` the moment the project is linked with services declared.

## Verified on a live preview, not assumed

| Route | Result |
|---|---|
| `/health` | 200 |
| `/api/auth/status` | 200 `{"authenticated":false,"user":null}` |
| `/api/problems/:id` | 200 |
| `/api/scans` | 401 while unauthenticated |
| `/dashboard` | 200 via SPA fallback |
| `POST /api/scan` | 200, real Chromium scan returning axe-core results |

That last row is the important one: `@sparticuz/chromium` with `puppeteer-core` genuinely running in the serverless function.

## Guard against a recurrence

The Octokit constraint is the kind a routine dependency bump undoes silently, so it is asserted rather than documented: `backend/tests/dependencies.test.js` fails if the installed `@octokit/rest` has no CommonJS entry. It checks the package shape rather than a version number, so it survives future 20.x releases and fails on the thing that actually breaks. Because deploys are gated on the test suite, that failure now blocks the deploy instead of reaching production.

`backend/README.md` records why the API is a traced function rather than a service, and the symptom to recognise if anyone switches it back — local modules failing to resolve inside the function while npm packages resolve fine.

## Also

`backend/app.js` moves to a named export. That was not the fix, but a bare `module.exports = fn` has no single agreed shape once anything bridges CommonJS and ESM, so naming it removes the ambiguity for good.
